### PR TITLE
Switch from ruby-haml to haml-coffee

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: site
 
 site:
-	cd site && haml-coffee -i markup/index.haml -o index.html
+	cd site && haml-coffee -i markup/index.haml -o index -r
 	cd site && lessc stylesheets/main.less stylesheets/style.css
 
 .PHONY: all site

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: site
 
 site:
-	cd site && haml markup/index.haml index.html
+	cd site && haml-coffee -i markup/index.haml -o index.html
 	cd site && lessc stylesheets/main.less stylesheets/style.css
 
 .PHONY: all site

--- a/site/markup/index.haml
+++ b/site/markup/index.haml
@@ -37,20 +37,20 @@
             });
 
     %body
-        -# = Haml::Engine.new(File.read('markup/header.haml')).render
+        +include "markup/header.haml"
         .container
             #sidebar-and-content
-                -# = Haml::Engine.new(File.read('markup/sidebar.haml')).render
+                +include "markup/sidebar.haml"
                 #content
                     #loader
                         %i.fa.fa-circle-o-notch.fa-spin
-                    -# = Haml::Engine.new(File.read('markup/pages/overview.haml')).render
-                    -# = Haml::Engine.new(File.read('markup/pages/mining.haml')).render
-                    -# = Haml::Engine.new(File.read('markup/pages/manage-account.haml')).render
-                    -# = Haml::Engine.new(File.read('markup/pages/money.haml')).render
-                    -# = Haml::Engine.new(File.read('markup/pages/files.haml')).render
-                    -# = Haml::Engine.new(File.read('markup/pages/hosting.haml')).render
-                    -# = Haml::Engine.new(File.read('markup/pages/transfer-funds.haml')).render
-                    -# = Haml::Engine.new(File.read('markup/pages/upload-file.haml')).render
-                    -# = Haml::Engine.new(File.read('markup/pages/network.haml')).render
-        -# = Haml::Engine.new(File.read('markup/hovering.haml')).render
+                    +include "markup/pages/overview.haml"
+                    +include "markup/pages/mining.haml"
+                    +include "markup/pages/manage-account.haml"
+                    +include "markup/pages/money.haml"
+                    +include "markup/pages/files.haml"
+                    +include "markup/pages/hosting.haml"
+                    +include "markup/pages/transfer-funds.haml"
+                    +include "markup/pages/upload-file.haml"
+                    +include "markup/pages/network.haml"
+        +include "markup/hovering.haml"

--- a/site/markup/index.haml
+++ b/site/markup/index.haml
@@ -37,10 +37,10 @@
             });
 
     %body
-        = Haml::Engine.new(File.read('markup/header.haml')).render
+        -# = Haml::Engine.new(File.read('markup/header.haml')).render
         .container
             #sidebar-and-content
-                = Haml::Engine.new(File.read('markup/sidebar.haml')).render
+                -# = Haml::Engine.new(File.read('markup/sidebar.haml')).render
                 #content
                     #loader
                         %i.fa.fa-circle-o-notch.fa-spin
@@ -53,4 +53,4 @@
                     -# = Haml::Engine.new(File.read('markup/pages/transfer-funds.haml')).render
                     -# = Haml::Engine.new(File.read('markup/pages/upload-file.haml')).render
                     -# = Haml::Engine.new(File.read('markup/pages/network.haml')).render
-        = Haml::Engine.new(File.read('markup/hovering.haml')).render
+        -# = Haml::Engine.new(File.read('markup/hovering.haml')).render

--- a/site/markup/index.haml
+++ b/site/markup/index.haml
@@ -44,13 +44,13 @@
                 #content
                     #loader
                         %i.fa.fa-circle-o-notch.fa-spin
-                    = Haml::Engine.new(File.read('markup/pages/overview.haml')).render
-                    = Haml::Engine.new(File.read('markup/pages/mining.haml')).render
-                    = Haml::Engine.new(File.read('markup/pages/manage-account.haml')).render
-                    = Haml::Engine.new(File.read('markup/pages/money.haml')).render
-                    = Haml::Engine.new(File.read('markup/pages/files.haml')).render
-                    = Haml::Engine.new(File.read('markup/pages/hosting.haml')).render
-                    = Haml::Engine.new(File.read('markup/pages/transfer-funds.haml')).render
-                    = Haml::Engine.new(File.read('markup/pages/upload-file.haml')).render
-                    = Haml::Engine.new(File.read('markup/pages/network.haml')).render
+                    -# = Haml::Engine.new(File.read('markup/pages/overview.haml')).render
+                    -# = Haml::Engine.new(File.read('markup/pages/mining.haml')).render
+                    -# = Haml::Engine.new(File.read('markup/pages/manage-account.haml')).render
+                    -# = Haml::Engine.new(File.read('markup/pages/money.haml')).render
+                    -# = Haml::Engine.new(File.read('markup/pages/files.haml')).render
+                    -# = Haml::Engine.new(File.read('markup/pages/hosting.haml')).render
+                    -# = Haml::Engine.new(File.read('markup/pages/transfer-funds.haml')).render
+                    -# = Haml::Engine.new(File.read('markup/pages/upload-file.haml')).render
+                    -# = Haml::Engine.new(File.read('markup/pages/network.haml')).render
         = Haml::Engine.new(File.read('markup/hovering.haml')).render

--- a/site/markup/pages/hosting.haml
+++ b/site/markup/pages/hosting.haml
@@ -25,7 +25,7 @@
                     .col-xs-4
                         .name Property Name
                     .col-xs-8
-                        .value{:contentEditable=>:true} 0
+                        .value{:contentEditable=>"true"} 0
         .control
             .warning
                 Warning: Changing hosting configuration values frequently will reduce client selections


### PR DESCRIPTION
In an effort to lower our dependencies (and make windows installation easier) I've removed all ruby-haml specific markup and converted it to coffee-haml markup.

Coffee-haml is advantageous to use b/c
1. We no longer have to install a random ruby gem
2. We could now potentially use the grunt build manager (woot, no more build dependency annoyances!)
3. The node package manager is already need for `lessc`, so it's nbd to install `haml-coffee` as well