### PR TITLE
Fixes the network ui tab

### DIFF
--- a/site/scripts/ui/views/network.js
+++ b/site/scripts/ui/views/network.js
@@ -1,6 +1,8 @@
+'use strict';
 ui._network = (function(){
 
 
+//	var view, eItems, eItemBlueprint, eAddPeer, eApply;
     function init(){
         view = $("#network");
         eItems = $();
@@ -27,7 +29,7 @@ ui._network = (function(){
         ui._trigger("update-peers", peerAddresses);
     }
 
-    function addPeer(peerAddr){
+    function addPeer(peerAddr, b, c){
         var eItem = eItemBlueprint.clone().removeClass("blueprint");
         eItemBlueprint.parent().append(eItem);
         eItem.find(".cancel").click(function(){
@@ -42,12 +44,10 @@ ui._network = (function(){
 
     function onViewOpened(data){
 
-        if (data.peer){
+        if (data && data.peer){
             eItems.remove();
             eItems = $();
-            data.peer.Peers.forEach(function(peerAddr){
-                addPeer(peerAddr);
-            });
+            data.peer.Peers.forEach(addPeer);
         }
 
     }


### PR DESCRIPTION
'use strict' is required for tab accessibility. Without it, the forEach() calls a function of undefined type. addPeer() now has three arguments as forEach() expects a callback with three items. The if() statement has been modified to account for a NULL data object in addition to a NULL data.peer.