### PR TITLE
ignoring node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.html
 sia.wallet
 *.css
+node_modules


### PR DESCRIPTION
`node_modules` is a folder created when `npm install` is run- it doesn't need to be committed