### PR TITLE
Simplified build & run process to `npm install` and `npm start`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ sudo: false
 language: node_js
 node_js:
   - 0.10
-before_install:
-  - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,7 @@ module.exports = function(grunt){
     grunt.loadNpmTasks('grunt-shell');
 
     grunt.registerTask('default', ['execute','less', 'download-atom-shell']);
-    grunt.registerTask('run', ['shell']);
+    grunt.registerTask('test', ['execute', 'less']);
+    grunt.registerTask('run', ['default', 'shell']);
 
 };

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 This is the user interface for [Sia](https://github.com/NebulousLabs/Sia), it is a desktop application based off the
 [atom-shell](https://github.com/atom/atom-shell) framework.
 
-## Running the application
+## Prerequesits
+
+- [siad](https://github.com/NebulousLabs/Sia)
 
 There are prebuilt binaries [nowhere](https://github.com/NebulousLabs/Sia-UI/issues/7)
 
-If you're developing the application and want to run without building...
+## Building and Running
 
-1. Download and install atom-shell using pre-built binaries [here](https://github.com/atom/atom-shell/releases)
-2. Run `/path/to/atom /path/to/Sia-UI`
+1. `npm install`
+2. `npm start`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the user interface for [Sia](https://github.com/NebulousLabs/Sia), it is
 
 - [siad](https://github.com/NebulousLabs/Sia)
 
-There are prebuilt binaries [nowhere](https://github.com/NebulousLabs/Sia-UI/issues/7)
+There are prebuilt binaries [here](https://sia-builder.cyrozap.com/job/sia/lastSuccessfulBuild/).
 
 ## Building and Running
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "coffee-script": "^1.9.1",
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-less": "^1.0.0",
     "grunt-download-atom-shell": "^0.12.0",
     "grunt-execute": "^0.2.2",
@@ -13,6 +14,7 @@
     "less": "^2.4.0"
   },
   "scripts": {
-    "test": "grunt"
+    "start": "node_modules/grunt-cli/bin/grunt run",
+    "test": "node_modules/grunt-cli/bin/grunt test"
   }
 }


### PR DESCRIPTION
This change makes it so you only have to run `npm install` to install everything and `npm start` to run Sia-UI. This also addresses issue #41.