### PR TITLE
Fixed `npm start` on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git://github.com/NebulousLabs/Sia-UI.git"
   },
   "scripts": {
-    "start": "node_modules/grunt-cli/bin/grunt run",
-    "test": "node_modules/grunt-cli/bin/grunt test"
+    "start": "grunt run",
+    "test": "grunt test"
   }
 }


### PR DESCRIPTION
It turns out npm is smart enough to search the binary directories of a module's dependencies in order to find executables to run in the npm scripts. By removing the relative paths, this commit should fix the issue on Windows.