### PR TITLE
Added Node module and Atom Shell caching to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - 0.10
+cache:
+  directories:
+    - atom-shell
+    - node_modules


### PR DESCRIPTION
Now that we're using the container-based infrastructure, caching should speed up our build a little.