### PR TITLE
autofill save dialog with nickname

### DIFF
--- a/main.js
+++ b/main.js
@@ -102,8 +102,8 @@ function loadConfig() {
 }
 
 function setupIPCHandlers() {
-    ipc.on("save-file-dialog", function(event){
-        var downloadPath = dialog.showSaveDialog();
+    ipc.on("save-file-dialog", function(event, filename){
+        var downloadPath = dialog.showSaveDialog({defaultPath: filename});
         event.returnValue = downloadPath ? downloadPath : null;
     });
     ipc.on("share-file", function(event, asciiText){

--- a/site/scripts/controller/controller.js
+++ b/site/scripts/controller/controller.js
@@ -128,7 +128,7 @@ var controller = (function() {
             });
         });
         ui.addListener("download-file", function(fileNickname) {
-            var savePath = ipc.sendSync("save-file-dialog");
+            var savePath = ipc.sendSync("save-file-dialog", fileNickname);
             if (!savePath) {
                 return
             }


### PR DESCRIPTION
Not much of an improvement, sadly.
However, we may have other reasons to use `defaultPath`, such as using the user's default download directory.