### PR TITLE
Jsdoc

### DIFF
--- a/.jsdocrc
+++ b/.jsdocrc
@@ -13,7 +13,7 @@
 	],
 	"opts": {
 		"template"              : "./node_modules/ink-docstrap/template",
-		"tutorials"             : "./doc/tutorials/",
+		"tutorials"             : "./doc/",
 		"package"               : "package.json",
 		"readme"                : "README.md",
 		"destination"           : "./doc/",

--- a/app/index.js
+++ b/app/index.js
@@ -5,15 +5,11 @@ const BrowserWindow = require('browser-window');
 const Tray = require('tray');
 // visit localhost:9222 to see devtools remotely
 App.commandLine.appendSwitch('remote-debugging-port', '9222');
-/**
- * Global reference to the window object, so the window won't be closed
- * automatically upon execution and garbage collection
- */
+// Global reference to the window object, so the window won't be closed
+// automatically upon execution and garbage collection
 var mainWindow;
 
-/**
- * Creates the window and loads index.html
- */
+// Creates the window and loads index.html
 function startMainWindow() {
 	// Open the UI with full screen size. 'screen' can only be required after
 	// app.on('ready') 
@@ -45,16 +41,12 @@ function startMainWindow() {
 	});
 }
 
-/**
- * Quit when all windows are closed.
- */
+// Quit when all windows are closed.
 App.on('window-all-closed', function() {
 	if (process.platform !== 'darwin') {
 		App.quit();
 	}
 });
 
-/**
- * When Electron loading has finished, start the daemon then the UI
- */
+// When Electron loading has finished, start the daemon then the UI
 App.on('ready', startMainWindow);

--- a/app/js/daemonAPI.js
+++ b/app/js/daemonAPI.js
@@ -14,14 +14,7 @@
  * @property {Object} args - The arguments to send with the call
  */
 
-/**
- * Creates an XMLHttpRequest to send
- * @param {string} url - The address (usually localhost) and port of siad
- * @param {string} type - The call type, such as 'POST' or 'GET'
- * @param {Object} args - The arguments to send with the call
- * @param {apiResponse} callback
- * @private
- */
+// Creates an XMLHttpRequest to send
 function sendCall(url, type, args, callback) {
 	// Detect improper calls, each one needs a url
 	if (!url || !type || !args) {
@@ -54,12 +47,7 @@ function sendCall(url, type, args, callback) {
 	request.send(args);
 } 
 
-/**
- * Takes any call object and makes the correct call
- * @param {apiCall} call - The call object with parameters
- * @param {apiResponse} callback
- * @private
- */
+// Takes any call object and makes the correct call
 function discernCall(call, callback) {
 	// Extract call attributes, default call is 'GET'
 	var url = call.url;

--- a/app/js/daemonManager.js
+++ b/app/js/daemonManager.js
@@ -8,22 +8,12 @@ var API = require('./js/daemonAPI');
  * @class DaemonManager
  */
 function DaemonManager() {
-	/**
-	 * The file system location of Sia and siad
-	 * @member {string} DaemonManager~siaPath
-	 */
+	// The file system location of Sia and siad
 	var siaPath;
-	/**
-	 * The localhost:port (default is 9980)
-	 * @member {string} DaemonManager~address
-	 */
+	// The localhost:port (default is 9980)
 	var address;
 
-	/**
-	 * Relays calls to daemonAPI with the localhost:port address appended
-	 * @param {apiCall} call - function to run if Siad is running
-	 * @param {apiResponse} callback
-	 */
+	// Relays calls to daemonAPI with the localhost:port address appended
 	function apiCall(call, callback) {
 		// Interpret address-only calls as 'GET'
 		if (typeof call === 'string') {
@@ -35,11 +25,7 @@ function DaemonManager() {
 		API.makeCall(call, callback);
 	}
 
-	/**
-	 * Detects whether siad is running on the current address
-	 * @param {function} isRunning - function to run if Siad is running
-	 * @param {function} isNotRunning - function to run if Siad is not running
-	 */
+	// Detects whether siad is running on the current address
 	function ifSiad(isRunning, isNotRunning) {
 		if (!isRunning) {
 			isRunning = function() {};
@@ -56,9 +42,7 @@ function DaemonManager() {
 		});
 	}
 
-	/**
-	 * Starts the daemon as a long running background process
-	 */
+	// Starts the daemon as a long running background process
 	function start() {
 		ifSiad(function() {
 			console.error('attempted to start siad when it was already running');
@@ -80,9 +64,7 @@ function DaemonManager() {
 		daemonProcess.unref();
 	}
 
-	/**
-	 * Stops the daemon
-	 */
+	// Stops the daemon
 	function stop() {
 		ifSiad(function() {
 			console.log('stopping siad');
@@ -96,11 +78,7 @@ function DaemonManager() {
 		});
 	}
 
-	/**
-	 * Sets the member variables based on the passed config
-	 * @param {config} config - the config object derived from config.json
-	 * @param {callback} callback
-	 */
+	// Sets the member variables based on the passed config
 	function setConfig(config, callback) {
 		siaPath = Path.join(config.depsPath, 'Sia');
 		address = config.siadAddress;

--- a/app/js/plugin.js
+++ b/app/js/plugin.js
@@ -8,15 +8,9 @@ var Factory = require('./pluginFactory');
  * @param {string} name - The name of the plugin.
  */
 function Plugin(plugPath, name) {
-	/**
-	 * Html element for the webview
-	 * @member {Object} Plugin~view
-	 */
+	// Html element for the webview
 	var view = new Factory.view(Path.join(plugPath, name, 'index.html'), name);
-	/**
-	 * Html element for the sidebar button
-	 * @member {Object} Plugin~button
-	 */
+	// Html element for the sidebar button
 	var button = new Factory.button(Path.join(plugPath, name, 'assets', 'button.png'), name);
 
 	return {

--- a/app/js/pluginFactory.js
+++ b/app/js/pluginFactory.js
@@ -1,11 +1,6 @@
 'use strict';
 
-/**
- * Creates the image element for a button
- * @param {string} path - The path to the icon.
- * @private
- * @returns {Object} - The button image element
- */
+// Creates the image element for a button
 function icon(path) {
 	var i = document.createElement('img');
 	i.src = path;
@@ -13,12 +8,7 @@ function icon(path) {
 	return i;
 }
 
-/**
- * Creates the text element for a button
- * @param {string} name - The name of the plugin.
- * @private
- * @returns {Object} - The button text element
- */
+// Creates the text element for a button
 function text(name) {
 	var t = document.createElement('div');
 	t.innerText = name;

--- a/app/js/pluginManager.js
+++ b/app/js/pluginManager.js
@@ -6,33 +6,17 @@ var Plugin = require('./js/plugin');
  * @class PluginManager
  */
 function PluginManager() {
-	/**
-	 * The home view to be opened first
-	 * @member {string} PluginManager~home
-	 */
+	// The home view to be opened first
 	var home;
-	/**
-	 * The plugins folder
-	 * @member {string} PluginManager~plugPath
-	 */
+	// The plugins folder
 	var plugPath;
-	/**
-	 * The current plugin
-	 * @member {Plugin} PluginManager~current
-	 */
+	// The current plugin
 	var current;
-	/**
-	 * Array to store all plugins
-	 * @member {Plugin[]} PluginManager~plugins
-	 */
+	// Array to store all plugins
 	var plugins = [];
 
-	/**
-	 * Detects the home Plugin or otherwise the alphabetically first
-	 * plugin and sets its button and view to be first in order
-	 * @function PluginManager~setHome
-	 * @param {string[]} pluginNames - array of subdirectories of app/plugins/
-	 */
+	// Detects the home Plugin or otherwise the alphabetically first
+	// plugin and sets its button and view to be first in order
 	function setHome(pluginNames) {
 		// Detect if home plugin is installed
 		var homeIndex = pluginNames.indexOf(home);
@@ -46,11 +30,7 @@ function PluginManager() {
 		home = pluginNames[0];
 	}
 
-	/**
-	 * Handles listening for plugin messages and reacting to them
-	 * @function PluginManager~addListeners
-	 * @param {Plugin} plugin - a newly made plugin object
-	 */
+	// Handles listening for plugin messages and reacting to them
 	function addListeners(plugin) {
 		// Only show the default plugin view
 		if (plugin.name === home) {
@@ -101,11 +81,7 @@ function PluginManager() {
 		});	
 	}
 
-	/**
-	 * Constructs the plugins and adds them to this manager 
-	 * @function PluginManager~addPlugin
-	 * @param {string} name - The plugin folder's name
-	 */
+	// Constructs the plugins and adds them to this manager 
 	function addPlugin(name) {
 		// Make the plugin, giving its button a standard transition
 		var plugin = new Plugin(plugPath, name);
@@ -117,10 +93,7 @@ function PluginManager() {
 		plugins.push(plugin);
 	}
 
-	/**
-	 * Reads the config's plugPath for plugin folders
-	 * @function PluginManager~initPlugins
-	 */
+	// Reads the config's plugPath for plugin folders
 	function initPlugins() {
 		Fs.readdir(plugPath, function (err, pluginNames) {
 			if (err) {
@@ -135,13 +108,8 @@ function PluginManager() {
 		});
 	}
 
-	/**
-	 * Sets the member variables based on the passed config
-	 * @function PluginManager~setConfig
-	 * @param {config} config - config in memory
-	 * @param {callback} callback
-	 * @todo delete all plugins when a new path is set?
-	 */
+	// Sets the member variables based on the passed config
+	// TODO: delete all plugins when a new path is set?
 	function setConfig(config, callback) {
 		home = config.homePlugin;
 		plugPath = config.pluginsPath;

--- a/app/js/uiManager.js
+++ b/app/js/uiManager.js
@@ -6,10 +6,7 @@ var Config = require('./js/uiConfig.js');
  * @class UIManager
  */
 function UIManager() {
-	/**
-	 * Config.json variables
-	 * @member {string} UIManager~configPath
-	 */
+	// Config.json variables
 	var configPath = Path.join(__dirname, 'config.json');
 	/**
 	 * Config variable held in working memory


### PR DESCRIPTION
I made this branch originally to jsdoc up the plugins, however after some thinking and reading, I decided not to.

JSDoc is a tool made for autogenerating docs to ease the understanding inter-JS-file interaction. Thus private member variables, functions, and self-contained logic do not need the excessive JSDoc comment syntax. Plugins, since they are self-contained and mostly have individual js files, also do not need it.
