### PR TITLE
Siadhandling

### DIFF
--- a/app/css/general.css
+++ b/app/css/general.css
@@ -212,20 +212,6 @@ html,body {
   font-size: 18px;
   color: #757575;
 }
-.notification.small .icon {
-  height: 40px;
-  width: 40px;
-  line-height: 40px;
-  font-size: 24px;
-}
-.notification.small .content {
-  padding: 0px;
-  padding-left: 14px;
-  line-height: 40px;
-  height: 40px;
-  width: 360px;
-  overflow-x: hidden;
-}
 .notification.hoverable:hover {
   cursor: pointer;
   box-shadow: 0px 0px 16px 0px rgba(0, 0, 0, 0.4);

--- a/app/index.html
+++ b/app/index.html
@@ -46,6 +46,7 @@
 		<!-- Javascript -->
 		<script> 
 			const WebFrame = require("web-frame");
+			const IPC = require("ipc");
 			const ElectronScreen = require("screen");
 			const Process = require('child_process').spawn;
 			const Path = require("path");

--- a/app/js/daemonManager.js
+++ b/app/js/daemonManager.js
@@ -50,7 +50,7 @@ function DaemonManager() {
 	 * @param {function} isNotRunning - function to run if Siad is not running
 	 */
 	function ifSiad(isRunning, isNotRunning) {
-		apiCall('/consensus/status', function(err) {
+		apiCall('/consensus', function(err) {
 			if (!err) {
 				self.Running = true;
 				isRunning();
@@ -117,41 +117,12 @@ function DaemonManager() {
 			UI.notify('siad errored: ' + error, 'error');
 		});
 		// Listen for siad exiting
-		daemonProcess.on('exit', exit);
-	}
-
-	/**
-	 * Stops the daemon
-	 */
-	function stop() {
-		ifSiad(function() {
-			UI.notify('Stopping siad...', 'stop');
-		}, function() {
-			console.err('attempted to stop siad when it was not running');
-			return;
-		});
-		apiCall('/daemon/stop', function(err, result) {
-			if (result.Success) {
-				exit();
-			} else {
-				console.error(err);
-			}
-		});
-	}
-
-	function exit(code) {
-		self.Running = false;
-		if (code) {
+		daemonProcess.on('exit', function(code) {
+			self.Running = false;
 			UI.notify('siad exited with code: ' + code, 'stop');
-		} else {
-			UI.notify('siad exited', 'stop');
-		}
-		setTimeout(function() {
-			IPC.send('exit');
-		}, 400);
-		clearTimeout(updating);
+			clearTimeout(updating);
+		});
 	}
-
 
 	/**
 	 * Sets the member variables based on the passed config

--- a/app/js/daemonManager.js
+++ b/app/js/daemonManager.js
@@ -21,11 +21,6 @@ function DaemonManager() {
 	 */
 	var address;
 	/**
-	 * Empty function to use with ifSiad()
-	 * @member {function} DaemonManager~EMPTYFUNC
-	 */
-	var EMPTYFUNC = function() {};
-	/**
 	 * Boolean to track if siad is running
 	 * @member {function} DaemonManager.Running
 	 */
@@ -76,7 +71,7 @@ function DaemonManager() {
 				UI.notify('Update check failed!', 'error');
 				return;
 			} else if (update.Available) {
-				UI.notify("New Sia Client Available: Click to update to " + update.Version, "download", function() {
+				UI.notify("New Sia Client Available: Click to update to " + update.Version, "update", function() {
 					Shell.openExternal('https://www.github.com/NebulousLabs/Sia-UI/releases');
 				});
 			} else {

--- a/app/js/plugin.js
+++ b/app/js/plugin.js
@@ -49,7 +49,7 @@ function Plugin(plugPath, name) {
 		*/
 		show: function() {
 			button.classList.add('current');
-			view.executeJavaScript('if (typeof show === "function") show();');
+			view.executeJavaScript('if (typeof start === "function") start();');
 			setTimeout(function() {
 				view.style.display = '';
 			}, 250);
@@ -61,7 +61,7 @@ function Plugin(plugPath, name) {
 		*/
 		hide: function() {
 			button.classList.remove('current');
-			view.executeJavaScript('if (typeof hide === "function") hide();');
+			view.executeJavaScript('if (typeof stop === "function") stop();');
 			setTimeout(function() {
 				view.style.display = 'none';
 			}, 250);

--- a/app/js/pluginManager.js
+++ b/app/js/pluginManager.js
@@ -99,7 +99,8 @@ function PluginManager() {
 						Daemon.apiCall(call, function(err, result) {
 							if (err) {
 								console.error(err);
-							} else if (responseChannel) {
+							} 
+							if (responseChannel) {
 								plugin.sendToView(responseChannel, err, result);
 							}
 						});

--- a/app/js/pluginManager.js
+++ b/app/js/pluginManager.js
@@ -185,20 +185,4 @@ function PluginManager() {
 	this.init = function(config) {
 		setConfig(config, initPlugins);
 	};
-	
-	/**
-	 * Starts the functionality of the plugin, used only after it's been stopped
-	 * @function PluginManager.start
-	 */
-	this.start = function() {
-		current.start();
-	}
-
-	/**
-	 * Stops the functionality of the plugin, used when siad has stopped
-	 * @function PluginManager.stop
-	 */
-	this.stop = function() {
-		current.stop();
-	}
 }

--- a/app/js/pluginManager.js
+++ b/app/js/pluginManager.js
@@ -70,14 +70,19 @@ function PluginManager() {
 		 * @todo Add smoother transitions
 		 */
 		plugin.transition(function() {
+			// Don't do anything if already on this plugin
 			if (current === plugin) {
 				return;
 			}
+
+			// Fadein and fadeout mainbar
 			var main = document.getElementById('mainbar').classList;
 			main.add('transition');
 			setTimeout(function() {
 				main.remove('transition');
 			}, 250);
+
+			// Switch plugins
 			current.hide();
 			current = plugin;
 			current.show();
@@ -87,13 +92,18 @@ function PluginManager() {
 		plugin.on('ipc-message', function(event) {
 			switch(event.channel) {
 				case 'api-call':
+					// Redirect api calls to the daemonManager
 					var call = event.args[0];
 					var responseChannel = event.args[1];
-					Daemon.apiCall(call, function(err, result) {
-						if (responseChannel) {
-							plugin.sendToView(responseChannel, err, result);
-						}
-					});
+					if (Daemon.Running) {
+						Daemon.apiCall(call, function(err, result) {
+							if (err) {
+								console.error(err);
+							} else if (responseChannel) {
+								plugin.sendToView(responseChannel, err, result);
+							}
+						});
+					}
 					break;
 				case 'notify':
 					// Use UI notification system
@@ -169,10 +179,26 @@ function PluginManager() {
 
 	/**
 	 * Initializes the plugins to the UI
-	 * @function PluginManager~init
+	 * @function PluginManager.init
 	 * @param {config} config - config in memory
 	 */
 	this.init = function(config) {
 		setConfig(config, initPlugins);
 	};
+	
+	/**
+	 * Starts the functionality of the plugin, used only after it's been stopped
+	 * @function PluginManager.start
+	 */
+	this.start = function() {
+		current.start();
+	}
+
+	/**
+	 * Stops the functionality of the plugin, used when siad has stopped
+	 * @function PluginManager.stop
+	 */
+	this.stop = function() {
+		current.stop();
+	}
 }

--- a/app/js/uiManager.js
+++ b/app/js/uiManager.js
@@ -27,11 +27,13 @@ function UIManager() {
 	var notificationsInQueue = 0;
 	var notificationIcons = {
 		alert: 'exclamation',
-		error: 'exclamation',
+		error: 'exclamation-circle',
 		update: 'arrow-circle-o-up',
 		upload: 'upload',
 		help: 'question',
 		sent: 'send',
+		start: 'play',
+		stop: 'stop',
 		received: 'sign-in',
 		fix: 'wrench',
 		download: 'arrow-circle-down',
@@ -152,7 +154,7 @@ function UIManager() {
 			top: 0,
 			left: 0,
 		};
-
+		// Show the tooltip at the proper location
 		eTooltip.show();
 		eTooltip.html(content);
 		var middleX = offset.left - (eTooltip.width()/2) + (offset.width/2);
@@ -161,7 +163,7 @@ function UIManager() {
             top: topY,
             left: middleX,
         });
-
+		// Fade the toolip from 0 to 1
 		if (!tooltipVisible) {
 			eTooltip.stop();
 			eTooltip.css({'opacity':0});
@@ -174,13 +176,13 @@ function UIManager() {
 			eTooltip.show();
 			eTooltip.css({'opacity':1});
 		}
-
+		// Hide the tooltip after 1.4 seconds
 		clearTimeout(tooltipTimeout);
 		tooltipTimeout = setTimeout(function() {
 			// eTooltip.hide();
 			eTooltip.animate({
 				'opacity':'0'
-			}, 400,function() {
+			}, 400, function() {
 				tooltipVisible = false;
 				eTooltip.hide();
 			});

--- a/app/js/uiManager.js
+++ b/app/js/uiManager.js
@@ -154,11 +154,11 @@ function UIManager() {
 		eTooltip.show();
 		eTooltip.html(content);
 		var middleX = offset.left - (eTooltip.width()/2) + (offset.width/2);
-        var topY = offset.top - (eTooltip.height()) - (offset.height/2);
-        eTooltip.offset({
-            top: topY,
-            left: middleX,
-        });
+		var topY = offset.top - (eTooltip.height()) - (offset.height/2);
+		eTooltip.offset({
+			top: topY,
+			left: middleX,
+		});
 		// Fade the toolip from 0 to 1
 		if (!tooltipVisible) {
 			eTooltip.stop();
@@ -232,7 +232,11 @@ function UIManager() {
 	* Called at window.beforeunload, closes the UI
 	* @function UIManager#kill
 	*/
-   this.kill = function() {
-	   Config.save(memConfig, configPath);
-   };
+	this.kill = function() {
+		Config.save(memConfig, configPath);
+		// Ensure the UI's closing
+		setTimeout(function() {
+			IPC.send('exit');
+		}, 400);
+	};
 }

--- a/app/js/uiManager.js
+++ b/app/js/uiManager.js
@@ -30,14 +30,10 @@ function UIManager() {
 		error: 'exclamation-circle',
 		update: 'arrow-circle-o-up',
 		upload: 'upload',
-		help: 'question',
 		sent: 'send',
 		start: 'play',
 		stop: 'stop',
-		received: 'sign-in',
-		fix: 'wrench',
 		download: 'arrow-circle-down',
-		peers: 'group',
 		success: 'check'
 	};
 

--- a/app/plugins/Overview/css/overview.css
+++ b/app/plugins/Overview/css/overview.css
@@ -26,3 +26,16 @@
 	margin-top: 20px;
 	font-size: 32px;
 }
+
+.button {
+	-webkit-animation: fadein 1s; /* Safari, Chrome and Opera > 12.1 */
+	margin-top: 20px;
+}
+.button.hidden {
+	-webkit-animation: fadeout 1s; /* Safari, Chrome and Opera > 12.1 */
+	opacity: 0;
+}
+.button:hover {
+	color: #4a4a4a;
+	cursor: pointer;
+}

--- a/app/plugins/Overview/index.html
+++ b/app/plugins/Overview/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<!-- CSS -->
 		<link rel="stylesheet" href="../../css/roboto-condensed-min.css">
+		<link rel="stylesheet" href="../../css/font-awesome-4.3.0/css/font-awesome.min.css">
 		<link rel="stylesheet" href="../../css/plugin-standard.css">
 		<link rel="stylesheet" href="css/overview.css">
 	</head>
@@ -22,6 +23,10 @@
 			<div class="welcome">
 				<div class="large">Welcome to Sia</div>
 				<div class="small">A highly efficient decentralized storage network.</div>
+				<div class="button" id="stop-exit">
+					<i class="fa fa-sign-out"></i>
+					Stop siad & exit
+				</div>
 			</div>
 		</div>
 		

--- a/app/plugins/Overview/index.html
+++ b/app/plugins/Overview/index.html
@@ -23,10 +23,6 @@
 			<div class="welcome">
 				<div class="large">Welcome to Sia</div>
 				<div class="small">A highly efficient decentralized storage network.</div>
-				<div class="button" id="stop-exit">
-					<i class="fa fa-sign-out"></i>
-					Stop siad & exit
-				</div>
 			</div>
 		</div>
 		

--- a/app/plugins/Overview/js/overview.js
+++ b/app/plugins/Overview/js/overview.js
@@ -49,6 +49,25 @@ function stop() {
 	clearTimeout(updating);
 }
 
+// Ask UI to show tooltip bubble
+function tooltip(message, element) {
+	var rect = element.getBoundingClientRect();
+	IPC.sendToHost('tooltip', message, {
+		top: rect.top,
+		bottom: rect.bottom,
+		left: rect.left,
+		right: rect.right,
+		height: rect.height,
+		width: rect.width,
+		length: rect.length,
+	});
+}
+
+document.getElementById('stop-exit').onclick = function() {
+	IPC.sendToHost('api-call', '/daemon/stop');
+	tooltip('Bye!', this);
+}
+
 // Define IPC listeners and update DOM per call
 IPC.on('balance-update', function(err, result) {
 	updateField(err, 'Balance: ', formatSiacoin(result.Balance), 'balance');

--- a/app/plugins/Overview/js/overview.js
+++ b/app/plugins/Overview/js/overview.js
@@ -63,11 +63,6 @@ function tooltip(message, element) {
 	});
 }
 
-document.getElementById('stop-exit').onclick = function() {
-	IPC.sendToHost('api-call', '/daemon/stop');
-	tooltip('Bye!', this);
-}
-
 // Define IPC listeners and update DOM per call
 IPC.on('balance-update', function(err, result) {
 	updateField(err, 'Balance: ', formatSiacoin(result.Balance), 'balance');

--- a/app/plugins/Overview/js/overview.js
+++ b/app/plugins/Overview/js/overview.js
@@ -35,8 +35,8 @@ function formatSiacoin(hastings) {
 	return display + ' SC';
 }
 
-// Called upon showing
-function show() {
+// Called by the UI upon showing
+function start() {
 	// DEVTOOL: uncomment to bring up devtools on plugin view
 	// IPC.sendToHost('devtools');
 	
@@ -44,8 +44,8 @@ function show() {
 	updating = setTimeout(update, 0);
 }
 
-// Called upon transitioning away from this view
-function hide() {
+// Called by the UI upon transitioning away from this view
+function stop() {
 	clearTimeout(updating);
 }
 

--- a/app/plugins/Wallet/index.html
+++ b/app/plugins/Wallet/index.html
@@ -29,9 +29,9 @@
 					<div class='title'>
 						Addresses
 					</div>
-					<div class='controls'>
-						<div class='button' id='create-address'>
-							<i class='fa fa-fw fa-plus'></i>
+					<div class="controls">
+						<div class="button" id="create-address">
+							<i class="fa fa-plus"></i>
 							Create Address
 						</div>
 					</div>
@@ -44,13 +44,13 @@
 					<div class='title'>
 						Transaction
 					</div>
-					<div class='controls'>
-						<div class='hidden button' id='confirm'>
-							<i class='fa fa-fw fa-check-circle'></i>
+					<div class="controls">
+						<div class="hidden button" id="confirm">
+							<i class="fa fa-check-circle"></i>
 							Confirm?
 						</div>
-						<div class='button' id='send-money'>
-							<i class='fa fa-fw fa-send'></i>
+						<div class="button" id="send-money">
+							<i class="fa fa-send"></i>
 							Send Money
 						</div>
 						<input type='number' id='transaction-amount' placeholder='Amount'>

--- a/app/plugins/Wallet/js/wallet.js
+++ b/app/plugins/Wallet/js/wallet.js
@@ -49,7 +49,7 @@ function update() {
 }
 
 // Called upon showing
-function show() {
+function start() {
 	// DEVTOOL: uncomment to bring up devtools on plugin view
 	// IPC.sendToHost('devtools');
 	
@@ -58,7 +58,7 @@ function show() {
 }
 
 // Called upon transitioning away from this view
-function hide() {
+function stop() {
 	clearTimeout(updating);
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const App = require('app');
+const IPC = require('ipc');
 const Path = require('path');
 const BrowserWindow = require('browser-window');
 const Tray = require('tray');
@@ -53,6 +54,16 @@ App.on('window-all-closed', function() {
 		App.quit();
 	}
 });
+
+/**
+ * Quit when asked to by the renderer.
+ */
+IPC.on('exit', function() {
+	if (process.platform !== 'darwin') {
+		App.quit();
+	}
+});
+
 
 /**
  * When Electron loading has finished, start the daemon then the UI


### PR DESCRIPTION
`plugin.show()` and `plugin.hide()` now calls, via IPC, `view.start()` and `view.stop()` for semantics and to differentiate between the two. `plugin.show()` is called upon the button being pressed and incorporates transition logic, `view.start()` is called to start updating and api calling.

This PR makes siad startup handling a bunch more explicit, sending notifications to the user upon the daemon starting, stopping, and exiting. A new public boolean, named, "Running" in the DaemonManager keeps track of if the DaemonManager is aware that siad has started. Prevents an infinite flow of failed API calls when Running is set to false.

TODO after PR accepted: prettify notifications and allow user to turn siad on and off
