### PR TITLE
Now checks siad status on each errored API call

### DIFF
--- a/app/js/daemonManager.js
+++ b/app/js/daemonManager.js
@@ -49,7 +49,7 @@ function DaemonManager() {
 	 * @param {function} isRunning - function to run if Siad is running
 	 * @param {function} isNotRunning - function to run if Siad is not running
 	 */
-	function ifSiad(isRunning, isNotRunning) {
+	this.ifSiad = function ifSiad(isRunning, isNotRunning) {
 		apiCall('/consensus', function(err) {
 			if (!err) {
 				self.Running = true;
@@ -87,7 +87,7 @@ function DaemonManager() {
 	 * Starts the daemon as a long running background process
 	 */
 	function start() {
-		ifSiad(function() {
+		self.ifSiad(function() {
 			console.error('attempted to start siad when it was already running');
 			return;
 		}, function() {
@@ -113,7 +113,7 @@ function DaemonManager() {
 		var updating = setTimeout(function() {
 			self.Running = true;
 			updatePrompt();
-		}, 1000);
+		}, 1500);
 
 		// Listen for siad erroring
 		daemonProcess.on('error', function (error) {
@@ -150,7 +150,7 @@ function DaemonManager() {
 	 */
 	this.init = function(config) {
 		setConfig(config, function() {
-			ifSiad(updatePrompt, start);
+			self.ifSiad(updatePrompt, start);
 		});
 	};
 	/**

--- a/app/js/pluginManager.js
+++ b/app/js/pluginManager.js
@@ -97,8 +97,12 @@ function PluginManager() {
 						Daemon.apiCall(call, function(err, result) {
 							if (err) {
 								console.error(err, call);
-							} 
-							if (responseChannel) {
+								Daemon.ifSiad(function() {
+									plugin.sendToView(responseChannel, err, result);
+								}, function() {
+									UI.notify('siad seems to have stopped working!', 'stop');
+								});
+							} else if (responseChannel) {
 								plugin.sendToView(responseChannel, err, result);
 							}
 						});


### PR DESCRIPTION
The logic being that if a call errored, '/consensus' better still be
reachable or siad is definitely not running anymore

Fixes #53 
