### PR TITLE
Wallet fixes

### DIFF
--- a/app/plugins/Wallet/js/buttons.js
+++ b/app/plugins/Wallet/js/buttons.js
@@ -106,7 +106,7 @@ addResultListener('coin-sent', function(result) {
 // Lock or unlock the wallet
 eID('lock-pod').onclick = function() {
 	var state = eID('lock-status').innerHTML;
-	if (!wallet.encrypted && state === 'Unencrypted') {
+	if (!wallet.encrypted && state === 'Create Wallet') {
 		encrypt();
 	} else if (wallet.unlocked && state === 'Unlocked') {
 		lock();

--- a/app/plugins/Wallet/js/buttons.js
+++ b/app/plugins/Wallet/js/buttons.js
@@ -105,16 +105,13 @@ addResultListener('coin-sent', function(result) {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Capsule ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Lock or unlock the wallet
 eID('lock-pod').onclick = function() {
-	var state = eID('lock-status').innerHTML;
-	if (!wallet.encrypted && state === 'Create Wallet') {
+	if (!wallet.encrypted) {
 		encrypt();
-	} else if (wallet.unlocked && state === 'Unlocked') {
+	} else if (wallet.unlocked) {
 		lock();
-	} else if (!wallet.unlocked && state === 'Locked'){
+	} else if (!wallet.unlocked) {
 		show('request-password');
 		eID('password-field').focus();
-	} else {
-		console.error('lock-pod disagrees with wallet variable!', wallet.unlocked, state);
 	}
 };
 

--- a/app/plugins/Wallet/js/buttons.js
+++ b/app/plugins/Wallet/js/buttons.js
@@ -106,7 +106,7 @@ addResultListener('coin-sent', function(result) {
 // Lock or unlock the wallet
 eID('lock-pod').onclick = function() {
 	var state = eID('lock-status').innerHTML;
-	if (!wallet.unlocked && state === 'Unencrypted') {
+	if (!wallet.encrypted && state === 'Unencrypted') {
 		encrypt();
 	} else if (wallet.unlocked && state === 'Unlocked') {
 		lock();

--- a/app/plugins/Wallet/js/lifecycle.js
+++ b/app/plugins/Wallet/js/lifecycle.js
@@ -29,9 +29,11 @@ addResultListener('update-status', function(result) {
 	if (wallet.unlocked && wallet.encrypted) {
 		eID('confirmed').innerHTML = 'Balance: ' + bal + ' S';
 		eID('uncomfirmed').innerHTML = 'Pending: ' + pend + ' S';
+		eID('confirmed').style.removeProperty('display');
+		eID('uncomfirmed').style.removeProperty('display');
 	} else {
-		eID('confirmed').innerHTML = 'Balance: Locked';
-		eID('uncomfirmed').innerHTML = 'Pending: Locked';
+		eID('confirmed').style.setProperty('display', 'none');
+		eID('uncomfirmed').style.display = 'none';
 	}
 });
 

--- a/app/plugins/Wallet/js/lifecycle.js
+++ b/app/plugins/Wallet/js/lifecycle.js
@@ -26,7 +26,7 @@ addResultListener('update-status', function(result) {
 	// Update balance confirmed and uncomfirmed
 	var bal = convertSiacoin(wallet.confirmedsiacoinbalance);
 	var pend = convertSiacoin(wallet.unconfirmedincomingsiacoins).sub(convertSiacoin(wallet.unconfirmedoutgoingsiacoins));
-	if (wallet.Unlocked && wallet.Encrypted) {
+	if (wallet.unlocked && wallet.encrypted) {
 		eID('confirmed').innerHTML = 'Balance: ' + bal + ' S';
 		eID('uncomfirmed').innerHTML = 'Pending: ' + pend + ' S';
 	} else {

--- a/app/plugins/Wallet/js/loaders.js
+++ b/app/plugins/Wallet/js/loaders.js
@@ -74,11 +74,11 @@ IPC.on('unlocked', function(err, result) {
 });
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Encrypting ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// setUnencrypted sets the wallet lock status to encrypted.
+// setUnencrypted sets the wallet lock status to unencrypted.
 function setUnencrypted() {
 	clearLockIcon();
-	eID('lock-status').innerHTML = 'Unencrypted';
-	eID('lock-icon').classList.add('fa-times');
+	eID('lock-status').innerHTML = 'Create Wallet';
+	eID('lock-icon').classList.add('fa-plus');
 }
 
 // Encrypt the wallet (only applies to first time opening)

--- a/release.sh
+++ b/release.sh
@@ -30,7 +30,7 @@ package() {
 			;;
 		win32)
 			electron_arch="win32-ia32"
-			sia_arch="windows_amd64"
+			sia_arch="windows_386"
 			;;
 		darwin)
 			electron_arch="darwin-x64"


### PR DESCRIPTION
woo, that's like 1 line per commit!

The wallet js feels really messy to me. The functions make use of a lot of implicit state, like DOM elements. Maybe that's normal for JS though. Also, the plugins in general have a loose coupling between IPC request and response functions; maybe callbacks could be used instead.

I'm thinking that instead of the `Unencrypted` pod, we should show a single `Create Wallet` pod, and only display balance/lock state after the wallet has been created. I'm just not sure if there's a scenario where the wallet would be both locked and unencrypted even after you created it. If you think it's a good idea I'll add it to this PR
