### PR TITLE
Fix Addresses list

### DIFF
--- a/app/plugins/Wallet/css/wallet.css
+++ b/app/plugins/Wallet/css/wallet.css
@@ -218,9 +218,15 @@
 }
 .entry .address {
 	display: inline-block;
-	width: 80%;
+	width: calc(80% - 25px);
 	text-align: left;
 	padding-right: 1%;
 	white-space: nowrap;
 	overflow: hidden;
 }
+.entry .copy-address {
+	float: right;
+	display: inline-block;
+	width: 25px;
+}
+

--- a/app/plugins/Wallet/index.html
+++ b/app/plugins/Wallet/index.html
@@ -25,6 +25,7 @@
 			<div class='listnum'></div>
 			<div class='txns'></div>
 			<div class='address'></div>
+			<div class='copy-address'><i class='fa fa-clipboard'></i></div>
 		</div>
 	</head>
 	<body>
@@ -111,9 +112,12 @@
 				<div class='row'>
 					<div class='title'>
 						Addresses
+						<div class='button' id='view-all-addresses'>
+							<i class='fa fa-refresh'></i>
+						</div>
 					</div>
 					<div class='controls'>
-						<input type='search' id='search-bar' placeholder='Search'></input>
+						<input type='search' id='search-bar' placeholder='Search addresses'></input>
 						<div class='button' id='create-address'>
 							<i class='fa fa-plus'></i>
 							Create Address

--- a/app/plugins/Wallet/js/buttons.js
+++ b/app/plugins/Wallet/js/buttons.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Address Creation  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Address Handling  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Address creation
 eID('create-address').onclick = function() {
 	tooltip('Creating...', this);
@@ -11,21 +11,25 @@ eID('create-address').onclick = function() {
 	IPC.sendToHost('api-call', call, 'new-address');
 };
 
-// Filter address list by search string
+// Start search when typing in Search field
 eID('search-bar').onkeyup = function() {
 	tooltip('Searching...', this);
 	var searchstr = eID('search-bar').value;
+	filterAddressList(searchstr);
+};
 
+// Filter address list by search string
+function filterAddressList(searchstr) {
 	NodeList.prototype.forEach = Array.prototype.forEach
 	var entries = eID('address-list').childNodes;
 	entries.forEach( function(entry) {
-		if (entry.querySelector('.address').innerHTML.indexOf(searchstr)) {
+		if (entry.querySelector('.address').innerHTML.indexOf(searchstr) || searchstr.length == 0) {
 			hide(entry);
 		} else {
 			show(entry);
 		}
 	});
-};
+}
 
 // Adds an address to the address list
 function appendAddress(address) {
@@ -43,7 +47,14 @@ function appendAddress(address) {
 addResultListener('new-address', function(result) {
 	notify('New address created', 'created');
 	appendAddress(result);
+	filterAddressList(result.address);
 });
+
+// Button to display all wallet addresses
+eID('view-all-addresses').onclick = function() {
+	NodeList.prototype.forEach = Array.prototype.forEach
+	eID('address-list').childNodes.forEach( function(entry) { show(entry); } );
+}
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Transactions ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Define send call
@@ -169,7 +180,6 @@ eID('password-field').addEventListener("keydown", function(e) {
 eID('confirm-password').onclick = function() {
 	hide('show-password');
 };
-
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Load ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 eID('load-legacy-wallet').onclick = function() {

--- a/app/plugins/Wallet/js/lifecycle.js
+++ b/app/plugins/Wallet/js/lifecycle.js
@@ -2,6 +2,9 @@
 
 var blockheight = 0;
 
+// Library for working with clipboard
+const Clipboard = require('clipboard');
+
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Updating  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Make API calls, sending a channel name to listen for responses
 function update(address) {
@@ -62,7 +65,7 @@ addResultListener('update-status', function(wallet) {
 	}
 });
 
-// Append wallet address to address list
+// Append wallet address to Addresses list
 function appendAddress(addr) {
 	// Create only new addresses
 	if (typeof(addr) == 'undefined') { return; }
@@ -80,15 +83,23 @@ function appendAddress(addr) {
 	field('.address').id = addr.address;
 	field('.address').addEventListener("click", getAddress);
 
-	// Display address
+	// Make copy-to-clipboard buttin clickable
+	field('.copy-address').onclick = function() {
+		Clipboard.writeText(addr.address);
+		notify('Copied address to clipboard');
+	};
+
+	// Append, but not do display, address
 	eID('address-list').appendChild(addrElement);
-	show(addrElement);
 	return;
 }
+
+// Display transactions of clicked address
 function getAddress(event) {
 	updateAddrTxn(event.target.id);
 }
 
+// Append a transaction to Transactions list
 function appendTransaction(txn) {
 	if (typeof(txn) == 'undefined') { return; }
 


### PR DESCRIPTION
Displaying all addresses may be slow and prone to hang the UI when there is a very large number of wallet addresses. Furthermore, users should be discouraged to re-use addresses. This PR improves the listing of addresses:
- Hide wallet addresses by default
- Display only new address when generated
- Add button to display all addresses
- Add copy-to-clipboard icon next to addresses
