### PR TITLE
Fix scoping issue

### DIFF
--- a/app/plugins/Wallet/js/lifecycle.js
+++ b/app/plugins/Wallet/js/lifecycle.js
@@ -53,7 +53,9 @@ function updateAddrTxn(addr) {
 }
 
 // Update wallet summary in header
-addResultListener('update-status', function(wallet) {
+addResultListener('update-status', function(result) {
+	wallet = result;
+
 	refreshRate = finalRefreshRate; // slow down after first successful call
 
 	// Show correct lock status.


### PR DESCRIPTION
Fixes `[12824:1017/032603:INFO:CONSOLE(154)] "Wallet plugin logged from buttons.js(157): lock-pod disagrees with wallet variable!", source: file:///X:/Dev/Sia-UI/app/js/pluginManager.js (154)`

The local `wallet` variable in the callback had a scope conflict with `wallet` in helper.js resulting in button.js not reading the correct state.
