### PR TITLE
Do not save `undefined` into config.json

### DIFF
--- a/app/js/uiConfig.js
+++ b/app/js/uiConfig.js
@@ -31,11 +31,13 @@ module.exports = {
 	 * @param {string} path - UI's defaultConfigPath
 	 */
 	save: function(config, path) {
-		Fs.writeFile(path, JSON.stringify(config, null, '\t'), function(err) {
-			if (err) {
-				console.log(err);
-			}
-		});
+		if (config !== undefined) {
+			Fs.writeFile(path, JSON.stringify(config, null, '\t'), function(err) {
+				if (err) {
+					console.log(err);
+				}
+			});
+		}
 	},
 
 	/**


### PR DESCRIPTION
Avoids a valid config.json being overwritten if UI tries to save `undefined` into it.
