### PR TITLE
Fixed release process for the nodified UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
 	"description": "A UI application for interfacing with Sia",
 	"license": "MIT",
 	"devDependencies": {
-		"bignumber.js": "^2.1.0",
 		"electron-prebuilt": "latest",
 		"ink-docstrap": "latest",
-		"jquery": "^2.1.4",
 		"jsdoc": "latest",
 		"jshint": "latest",
 		"node-inspector": "latest"
+	},
+	"dependencies": {
+		"bignumber.js": "^2.1.0",
+		"jquery": "^2.1.4"
 	},
 	"scripts": {
 		"start": "electron .",


### PR DESCRIPTION
Will probably just use https://github.com/maxogden/electron-packager in
the future as release.sh reinvents the wheel. It's extra work to use
release.sh and we don't even utilize electron's cross-platform
capabilities as well (i.e. our executable doesn't have an icon as well
as other features)
