### PR TITLE
Fixed contextMenu

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,6 @@
 			const Remote = require('remote');
 			const mainWindow = Remote.getCurrentWindow();
 		</script>
-		<script src='js/contextMenu.js'></script>
 		<script src='js/daemonManager.js'></script>
 		<script src='js/pluginManager.js'></script>
 		<script src='js/uiManager.js'></script>
@@ -66,6 +65,10 @@
 			var Plugins = new PluginManager();
 			window.onload = UI.init;
 			window.onbeforeunload = UI.kill;
+			window.addEventListener('contextmenu', function (e) {
+				e.preventDefault();
+				RendererIPC.send('context-menu');
+			}, false);
 		</script>
 	</body>
 </html>

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const BrowserWindow = require('browser-window');
 const Tray = require('tray');
 const Dialog = require('dialog');
 const Menu = require('menu');
+const contextMenu = require('./js/contextMenu.js');
+const appMenu = require('./js/appMenu.js');
 
 // visit localhost:9222 to see devtools remotely
 App.commandLine.appendSwitch('remote-debugging-port', '9222');
@@ -44,21 +46,7 @@ function startMainWindow() {
 	if (process.platform !== 'darwin') {
 		mainWindow.setMenuBarVisibility(false);
 	} else {
-		// Create the Application's main menu - enables copy-paste on Mac.
-		var appMenu = Menu.buildFromTemplate([
-			{
-				label: "Edit",
-				submenu: [
-					{ label: "Undo", accelerator: "CmdOrCtrl+Z", selector: "undo:" },
-					{ label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", selector: "redo:" },
-					{ type:  "separator" },
-					{ label: "Cut", accelerator: "CmdOrCtrl+X", selector: "cut:" },
-					{ label: "Copy", accelerator: "CmdOrCtrl+C", selector: "copy:" },
-					{ label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:" },
-					{ label: "Select All", accelerator: "CmdOrCtrl+A", selector: "selectAll:" },
-				]
-			}
-		]);
+		// Create the Application's main menu - OSX version might feel weird without a menubar
 		Menu.setApplicationMenu(appMenu);
 	}
 }
@@ -91,7 +79,7 @@ MainIPC.on('dialog', function(event, type, options) {
 	event.returnValue = response ? response : null;
 });
 
+// Enable right-click context menu from renderer process event
 MainIPC.on('context-menu', function(event, template) {
-	var contextMenu = Menu.buildFromTemplate(template);
 	contextMenu.popup(mainWindow);
 });

--- a/js/appMenu.js
+++ b/js/appMenu.js
@@ -1,0 +1,18 @@
+// Template for OSX app menu commands
+var template = [
+	{
+		label: 'Edit',
+		submenu: [
+			{ label: 'Undo', accelerator: 'CmdOrCtrl+Z', selector: 'undo:' },
+			{ label: 'Redo', accelerator: 'Shift+CmdOrCtrl+Z', selector: 'redo:' },
+			{ type:  'separator' },
+			{ label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
+			{ label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
+			{ label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
+			{ label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:' },
+		]
+	},
+];
+
+// Exports the created menu
+module.exports = require('menu').buildFromTemplate(template);

--- a/js/contextMenu.js
+++ b/js/contextMenu.js
@@ -1,34 +1,15 @@
+// Template for context menu commands
 var template = [
 	{
 		label: 'Edit',
 		submenu: [
-			{
-				label: 'Undo',
-				accelerator: 'CmdOrCtrl+Z',
-				role: 'undo'
-			}, {
-				label: 'Redo',
-				accelerator: 'Shift+CmdOrCtrl+Z',
-				role: 'redo'
-			}, {
-				type: 'separator'
-			}, {
-				label: 'Cut',
-				accelerator: 'CmdOrCtrl+X',
-				role: 'cut'
-			}, {
-				label: 'Copy',
-				accelerator: 'CmdOrCtrl+C',
-				role: 'copy'
-			}, {
-				label: 'Paste',
-				accelerator: 'CmdOrCtrl+V',
-				role: 'paste'
-			}, {
-				label: 'Select All',
-				accelerator: 'CmdOrCtrl+A',
-				role: 'selectall'
-			},
+			{ label: 'Undo', accelerator: 'CmdOrCtrl+Z', role: 'undo' },
+			{ label: 'Redo', accelerator: 'Shift+CmdOrCtrl+Z', role: 'redo' },
+			{ type:  'separator' },
+			{ label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
+			{ label: 'Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' },
+			{ label: 'Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' },
+			{ label: 'Select All', accelerator: 'CmdOrCtrl+A', role: 'selectall' },
 		]
 	}, {
 		label: 'View',
@@ -37,32 +18,37 @@ var template = [
 				label: 'Reload',
 				accelerator: 'CmdOrCtrl+R',
 				click: function(item, focusedWindow) {
-					if (focusedWindow)
+					if (focusedWindow) {
 						focusedWindow.reload();
+					}
 				}
 			}, {
 				label: 'Toggle Full Screen',
 				accelerator: (function() {
-					if (process.platform == 'darwin')
+					if (process.platform == 'darwin') {
 						return 'Ctrl+Command+F';
-					else
+					} else {
 						return 'F11';
+					}
 				})(),
 				click: function(item, focusedWindow) {
-					if (focusedWindow)
+					if (focusedWindow) {
 						focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+					}
 				}
 			}, {
 				label: 'Toggle Developer Tools',
 				accelerator: (function() {
-					if (process.platform == 'darwin')
+					if (process.platform == 'darwin') {
 						return 'Alt+Command+I';
-					else
+					} else {
 						return 'Ctrl+Shift+I';
+					}
 				})(),
 				click: function(item, focusedWindow) {
-					if (focusedWindow)
+					if (focusedWindow) {
 						focusedWindow.toggleDevTools();
+					}
 				}
 			},
 		]
@@ -70,24 +56,14 @@ var template = [
 		label: 'Window',
 		role: 'window',
 		submenu: [
-			{
-				label: 'Minimize',
-				accelerator: 'CmdOrCtrl+M',
-				role: 'minimize'
-			}, {
-				label: 'Close',
-				accelerator: 'CmdOrCtrl+W',
-				role: 'close'
-			},
+			{ label: 'Minimize', accelerator: 'CmdOrCtrl+M', role: 'minimize' },
+			{ label: 'Close', accelerator: 'CmdOrCtrl+W', role: 'close' },
 		]
 	}, {
 		label: 'Help',
 		role: 'help',
 		submenu: [
-			{
-				label: 'Learn More',
-				click: function() { require('shell').openExternal('http://sia.tech/') }
-			},
+			{ label: 'Learn More', click: function() { require('shell').openExternal('http://sia.tech/') } },
 		]
 	},
 ];
@@ -97,50 +73,24 @@ if (process.platform == 'darwin') {
 	template.unshift({
 		label: name,
 		submenu: [
-			{
-				label: 'About ' + name,
-				role: 'about'
-			}, {
-				type: 'separator'
-			}, {
-				label: 'Services',
-				role: 'services',
-				submenu: []
-			}, {
-				type: 'separator'
-			}, {
-				label: 'Hide ' + name,
-				accelerator: 'Command+H',
-				role: 'hide'
-			}, {
-				label: 'Hide Others',
-				accelerator: 'Command+Shift+H',
-				role: 'hideothers'
-			}, {
-				label: 'Show All',
-				role: 'unhide'
-			}, {
-				type: 'separator'
-			}, {
-				label: 'Quit',
-				accelerator: 'Command+Q',
-				click: function() { app.quit(); }
-			},
+			{ label: 'About ' + name, role: 'about' },
+			{ type:  'separator' },
+			{ label: 'Services', role: 'services', submenu: [] },
+			{ type:  'separator' },
+			{ label: 'Hide ' + name, accelerator: 'Command+H', role: 'hide' },
+			{ label: 'Hide Others', accelerator: 'Command+Shift+H', role: 'hideothers' },
+			{ label: 'Show All', role: 'unhide' },
+			{ type:  'separator' },
+			{ label: 'Quit', accelerator: 'Command+Q', click: function() { app.quit(); } },
 		]
 	});
 
 	// Window menu.
 	template[3].submenu.push(
-		{
-			type: 'separator'
-		}, {
-			label: 'Bring All to Front',
-			role: 'front'
-		}
+		{ type: 'separator' },
+		{ label: 'Bring All to Front', role: 'front' }
 	);
 }
 
-window.addEventListener('contextmenu', function (e) {
-	e.preventDefault();
-	RendererIPC.send('context-menu', template);
-}, false);
+// Exports the created menu
+module.exports = require('menu').buildFromTemplate(template);

--- a/js/plugin.js
+++ b/js/plugin.js
@@ -1,4 +1,5 @@
 'use strict';
+// Plugin Factory namespace to hold plugin creation logic
 var Factory = require('./pluginFactory');
 
 /**


### PR DESCRIPTION
Functions in View->Reload, Toggle Fullscreen, and Toggle Dev Tools weren't working. It was because functions can't be passed by IPC. Main process now loads, creates, and pops up the context menu based on an IPC message signalling the trigger of 'contextmenu' event from the renderer process.

Also organized the code to make index.js less cluttered.
