### PR TITLE
Spectron

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -80,14 +80,6 @@
 
 	"maxerr"        : 100,      // Maximum errors before stopping.
 	"globals"       : {         // Extra globals.
-		"WebFrame": false,
-		"ElectronScreen": false,
-		"RendererIPC": false,
-		"Fs": false,
-		"Shell": false,
-		"Process": false,
-		"Remote": false,
-		"mainWindow": true,
     	/* MOCHA */
     	"describe"   : false,
     	"it"         : false,

--- a/.jshintrc
+++ b/.jshintrc
@@ -80,13 +80,13 @@
 
 	"maxerr"        : 100,      // Maximum errors before stopping.
 	"globals"       : {         // Extra globals.
-    	/* MOCHA */
-    	"describe"   : false,
-    	"it"         : false,
-    	"before"     : false,
-    	"beforeEach" : false,
-    	"after"      : false,
-    	"afterEach"  : false
+		/* MOCHA */
+		"describe"   : false,
+		"it"         : false,
+		"before"     : false,
+		"beforeEach" : false,
+		"after"      : false,
+		"afterEach"  : false
 	},
 	"indent"        : 4         // Specify indentation spacing
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -88,9 +88,13 @@
 		"Process": false,
 		"Remote": false,
 		"mainWindow": true,
-		"UI": true,
-		"Daemon": true,
-		"Plugins": true
+    	/* MOCHA */
+    	"describe"   : false,
+    	"it"         : false,
+    	"before"     : false,
+    	"beforeEach" : false,
+    	"after"      : false,
+    	"afterEach"  : false
 	},
 	"indent"        : 4         // Specify indentation spacing
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ install:
   - npm install
   - test -z "$(npm run lint --silent)"
 
+before_script: chmod 0777 ./node_modules/.bin/electron-mocha
+
 script: 
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 language: node_js
+
 node_js:
   - "4.1"
   - "4.0"
   - "0.12"
   - "0.11"
 
-install:
-  - npm install
-  - test -z "$(npm run lint --silent)"
-
-before_script: chmod 0777 ./node_modules/.bin/electron-mocha
-
-script: 
+notifications:
+  email: false
 
 sudo: false
+
+addons:
+  apt:
+    packages:
+      - xvfb
+
+install:
+  - npm install
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/index.js
+++ b/index.js
@@ -11,6 +11,11 @@ const Menu = require('menu');
 const contextMenu = require('./js/contextMenu.js');
 const appMenu = require('./js/appMenu.js');
 
+// Uncomment to visit localhost:9222 to see devtools remotely
+// App.commandLine.appendSwitch('remote-debugging-port', '9222');
+// TODO: This seems to not let WebDriverIO tests run so it's commented out,
+// though I'm not sure why.
+
 // Global reference to the window object, so the window won't be closed
 // automatically upon execution and garbage collection
 var mainWindow;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 // Electron main process libraries
 const App = require('app');
 const MainIPC = require('ipc');
@@ -9,9 +10,6 @@ const Dialog = require('dialog');
 const Menu = require('menu');
 const contextMenu = require('./js/contextMenu.js');
 const appMenu = require('./js/appMenu.js');
-
-// visit localhost:9222 to see devtools remotely
-App.commandLine.appendSwitch('remote-debugging-port', '9222');
 
 // Global reference to the window object, so the window won't be closed
 // automatically upon execution and garbage collection

--- a/js/pluginManager.js
+++ b/js/pluginManager.js
@@ -144,7 +144,7 @@ function PluginManager() {
 					plugin.toggleDevTools();
 					break;
 				default:
-					console.log('Unknown ipc message: ' + event.channel);
+					console.error('Unknown ipc message: ' + event.channel);
 			}
 		});
 
@@ -182,9 +182,9 @@ function PluginManager() {
 	 * @function PluginManager~initPlugins
 	 */
 	function initPlugins() {
-		Fs.readdir(plugPath, function (err, pluginNames) {
+		Fs.readdir(plugPath, function(err, pluginNames) {
 			if (err) {
-				console.log(err);
+				console.error(err);
 			}
 
 			// Determine default plugin

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "description": "A UI application for interfacing with Sia",
   "license": "MIT",
   "devDependencies": {
+    "chai": "^3.4.1",
+    "chai-as-promised": "^5.1.0",
     "electron-packager": "^5.1.1",
     "electron-prebuilt": "^0.34.1",
     "ink-docstrap": "^0.5.2",
     "jsdoc": "^3.3.3",
     "jshint": "^2.8.0",
-    "node-inspector": "^0.12.3"
+    "node-inspector": "^0.12.3",
+    "spectron": "^0.34.0"
   },
   "dependencies": {
     "bignumber.js": "^2.1.0",
@@ -21,6 +24,7 @@
     "start": "electron .",
     "clean": "rm -rf release doc/Sia-UI node_modules Sia config.json **/*.swp npm-debug.log",
     "fresh": "npm run clean && npm install && npm start",
+    "test": "mocha",
     "debug": "node-inspector & electron --debug=5858 . & xdg-open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858",
     "doc": "jsdoc -c .jsdocrc",
     "lint": "jshint . --verbose --exclude-path=.jshintignore",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start": "electron .",
     "clean": "rm -rf release doc/Sia-UI node_modules Sia config.json **/*.swp npm-debug.log",
     "fresh": "npm run clean && npm install && npm start",
-    "test": "electron-mocha",
+    "test": "electron-mocha test/*",
     "debug": "node-inspector & electron --debug=5858 . & xdg-open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858",
     "doc": "jsdoc -c .jsdocrc",
     "lint": "jshint . --verbose --exclude-path=.jshintignore",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "ink-docstrap": "^0.5.2",
     "jsdoc": "^3.3.3",
     "jshint": "^2.8.0",
-    "node-inspector": "^0.12.3",
     "spectron": "^0.34.0"
   },
   "dependencies": {
@@ -25,8 +24,7 @@
     "start": "electron .",
     "clean": "rm -rf release doc/Sia-UI node_modules Sia config.json **/*.swp npm-debug.log",
     "fresh": "npm run clean && npm install && npm start",
-    "test": "electron-mocha test/*",
-    "debug": "node-inspector & electron --debug=5858 . & xdg-open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858",
+    "test": "electron-mocha",
     "doc": "jsdoc -c .jsdocrc",
     "lint": "jshint . --verbose --exclude-path=.jshintignore",
     "sia-repo": "go get -u github.com/NebulousLabs/Sia/...",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
+    "electron-mocha": "^0.6.1",
     "electron-packager": "^5.1.1",
     "electron-prebuilt": "^0.34.1",
     "ink-docstrap": "^0.5.2",
@@ -24,7 +25,7 @@
     "start": "electron .",
     "clean": "rm -rf release doc/Sia-UI node_modules Sia config.json **/*.swp npm-debug.log",
     "fresh": "npm run clean && npm install && npm start",
-    "test": "mocha",
+    "test": "electron-mocha",
     "debug": "node-inspector & electron --debug=5858 . & xdg-open http://127.0.0.1:8080/debug?ws=127.0.0.1:8080&port=5858",
     "doc": "jsdoc -c .jsdocrc",
     "lint": "jshint . --verbose --exclude-path=.jshintignore",

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,10 @@
 'use strict';
 
 // Libraries required for testing
-const Application = require('spectron').Application;
-const Chai = require('chai');
-const ChaiAsPromised = require('chai-as-promised');
-const Path = require('path');
-const Fs = require('fs');
+var Application = require('spectron').Application;
+var Chai = require('chai');
+var ChaiAsPromised = require('chai-as-promised');
+var Path = require('path');
 
 // Chai's should syntax is executed to edit Object to have Object.should
 var should = Chai.should();
@@ -13,16 +12,16 @@ var should = Chai.should();
 Chai.use(ChaiAsPromised);
 
 // The one app that this suite is testing is Sia-UI
-describe('Sia-UI', function () {
+describe('main process', function() {
 	var app;
 	var client;
 
 	// Starts a new session and assigns spectron's Application instance to a
 	// variable, app, available to all tests
-	beforeEach(function () {
+	before('start electron', function() {
 		app = new Application({
 			path: Path.join(__dirname, '../node_modules/.bin/electron'),
-			args: ['--app=' + Path.join(__dirname, '..')],
+			args: [Path.join(__dirname, '..')],
 		});
 		return app.start();
 	});
@@ -30,40 +29,38 @@ describe('Sia-UI', function () {
 	// Extends ChaiAsPromised's syntax with spectron's electron-specific
 	// functions and assigns spectron's WebDriverIO properties to a variable,
 	// client, available to all tests
-	beforeEach(function () {
+	before('transfer spectron methods', function() {
 		client = app.client;
 		ChaiAsPromised.transferPromiseness = client.transferPromiseness;
 	});
 
-	// Close Sia-UI session after each test-suite
-	afterEach(function () {
+	// Close session after each test-suite
+	after('stop electron', function() {
 		if (app && app.isRunning()) {
 			return app.stop();
 		}
 	});
 
 	// Test basic startup properties
-	describe('on startup', function () {
-		it('opens Sia-UI properly', function () {
-			return client.waitUntilWindowLoaded()
-				.getWindowCount().then(function(count) {
-					Fs.readdir(Path.join(__dirname, '../plugins'), function(err, plugins) {
-						should.not.exist(err);
-						// Not sure why, but the plugins sometimes register as
-						// part of the Window Count
-						count.should.equal(1 || 1 + plugins.length);
-					});
-				})
-				.isWindowMinimized().should.eventually.be.false
-				.isWindowDevToolsOpened().should.eventually.be.false
-				.isWindowVisible().should.eventually.be.true
-				.isWindowFocused().should.eventually.be.true
-				.getWindowWidth().should.eventually.be.above(0)
-				.getWindowHeight().should.eventually.be.above(0)
-				.getArgv().then(function(argv) {
-					argv[0].should.contain('electron');
-					argv[1].should.contain('Sia-UI');
-				});
+	describe('on startup', function() {
+		it('opens a window', function() {
+			return client.getWindowCount().should.eventually.equal(1);
+		});
+		it('isn\'t minimized', function() {
+			return client.isWindowMinimized().should.eventually.be.false;
+		});
+		it('has devtools line commented out', function() {
+			return client.isWindowDevToolsOpened().should.eventually.be.false;
+		});
+		it('is visible', function() {
+			return client.isWindowVisible().should.eventually.be.true;
+		});
+		it('is in focus', function() {
+			return client.isWindowFocused().should.eventually.be.true;
+		});
+		it('has non-zero width and height', function() {
+			return client.getWindowWidth().should.eventually.be.above(0)
+				.getWindowHeight().should.eventually.be.above(0);
 		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,33 +1,47 @@
-var Application = require('spectron').Application;
-var chai = require('chai');
-var chaiAsPromised = require('chai-as-promised');
-var path = require('path');
+'use strict';
 
-chai.should();
-chai.use(chaiAsPromised);
+// Libraries required for testing
+const Application = require('spectron').Application;
+const Chai = require('chai');
+const ChaiAsPromised = require('chai-as-promised');
+const Path = require('path');
 
+// Chai's should syntax is executed to edit Object to have Object.should
+Chai.should();
+// Chai's should syntax is extended to deal well with Promises
+Chai.use(ChaiAsPromised);
+
+// The one app that this suite is testing is Sia-UI
 describe('Sia-UI', function () {
 	var app;
 	var client;
+
+	// Starts a new session and assigns spectron's Application instance to a
+	// variable, app, available to all tests
 	beforeEach(function () {
 		app = new Application({
-			path: path.join(__dirname, '../node_modules/.bin/electron'),
-			args: ['--app=' + path.join(__dirname, '..')],
+			Path: Path.join(__dirname, '../node_modules/.bin/electron'),
+			args: ['--app=' + Path.join(__dirname, '..')],
 		});
 		return app.start();
 	});
 
+	// Extends ChaiAsPromised's syntax with spectron's electron-specific
+	// functions and assigns spectron's WebDriverIO properties to a variable,
+	// client, available to all tests
 	beforeEach(function () {
 		client = app.client;
-		chaiAsPromised.transferPromiseness = client.transferPromiseness;
+		ChaiAsPromised.transferPromiseness = client.transferPromiseness;
 	});
 
+	// Close Sia-UI session after each test-suite
 	afterEach(function () {
 		if (app && app.isRunning()) {
 			return app.stop();
 		}
 	});
 
+	// Test basic startup properties
 	describe('on startup', function () {
 		it('opens Sia-UI properly', function () {
 			return client.waitUntilWindowLoaded()

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,38 @@
+var Application = require('spectron').Application;
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+var path = require('path');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('application launch', function () {
+	beforeEach(function () {
+		this.app = new Application({
+			path: path.join(__dirname, '../node_modules/.bin/electron'),
+			args: [path.join(__dirname, '..')],
+		});
+		return this.app.start();
+	});
+
+	beforeEach(function () {
+		chaiAsPromised.transferPromiseness = this.app.client.transferPromiseness;
+	});
+
+	afterEach(function () {
+		if (this.app && this.app.isRunning()) {
+			return this.app.stop();
+		}
+	});
+
+	it('opens a window', function () {
+		return this.app.client.waitUntilWindowLoaded()
+			.getWindowCount().should.eventually.equal(1)
+			.isWindowMinimized().should.eventually.be.false
+			.isWindowDevToolsOpened().should.eventually.be.false
+			.isWindowVisible().should.eventually.be.true
+			.isWindowFocused().should.eventually.be.true
+			.getWindowWidth().should.eventually.be.above(0)
+			.getWindowHeight().should.eventually.be.above(0);
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ describe('Sia-UI', function () {
 	// variable, app, available to all tests
 	beforeEach(function () {
 		app = new Application({
-			Path: Path.join(__dirname, '../node_modules/.bin/electron'),
+			path: Path.join(__dirname, '../node_modules/.bin/electron'),
 			args: ['--app=' + Path.join(__dirname, '..')],
 		});
 		return app.start();
@@ -53,8 +53,8 @@ describe('Sia-UI', function () {
 				.getWindowWidth().should.eventually.be.above(0)
 				.getWindowHeight().should.eventually.be.above(0)
 				.getArgv().then(function(argv) {
-					argv[0].should.contain('electron')
-					argv[1].should.contain('Sia-UI')
+					argv[0].should.contain('electron');
+					argv[1].should.contain('Sia-UI');
 				});
 		});
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -6,33 +6,42 @@ var path = require('path');
 chai.should();
 chai.use(chaiAsPromised);
 
-describe('application launch', function () {
+describe('Sia-UI', function () {
+	var app;
+	var client;
 	beforeEach(function () {
-		this.app = new Application({
+		app = new Application({
 			path: path.join(__dirname, '../node_modules/.bin/electron'),
-			args: [path.join(__dirname, '..')],
+			args: ['--app=' + path.join(__dirname, '..')],
 		});
-		return this.app.start();
+		return app.start();
 	});
 
 	beforeEach(function () {
-		chaiAsPromised.transferPromiseness = this.app.client.transferPromiseness;
+		client = app.client;
+		chaiAsPromised.transferPromiseness = client.transferPromiseness;
 	});
 
 	afterEach(function () {
-		if (this.app && this.app.isRunning()) {
-			return this.app.stop();
+		if (app && app.isRunning()) {
+			return app.stop();
 		}
 	});
 
-	it('opens a window', function () {
-		return this.app.client.waitUntilWindowLoaded()
-			.getWindowCount().should.eventually.equal(1)
-			.isWindowMinimized().should.eventually.be.false
-			.isWindowDevToolsOpened().should.eventually.be.false
-			.isWindowVisible().should.eventually.be.true
-			.isWindowFocused().should.eventually.be.true
-			.getWindowWidth().should.eventually.be.above(0)
-			.getWindowHeight().should.eventually.be.above(0);
+	describe('on startup', function () {
+		it('opens Sia-UI properly', function () {
+			return client.waitUntilWindowLoaded()
+				.getWindowCount().should.eventually.equal(1)
+				.isWindowMinimized().should.eventually.be.false
+				.isWindowDevToolsOpened().should.eventually.be.false
+				.isWindowVisible().should.eventually.be.true
+				.isWindowFocused().should.eventually.be.true
+				.getWindowWidth().should.eventually.be.above(0)
+				.getWindowHeight().should.eventually.be.above(0)
+				.getArgv().then(function(argv) {
+					argv[0].should.contain('electron')
+					argv[1].should.contain('Sia-UI')
+				});
+		});
 	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -5,9 +5,10 @@ const Application = require('spectron').Application;
 const Chai = require('chai');
 const ChaiAsPromised = require('chai-as-promised');
 const Path = require('path');
+const Fs = require('fs');
 
 // Chai's should syntax is executed to edit Object to have Object.should
-Chai.should();
+var should = Chai.should();
 // Chai's should syntax is extended to deal well with Promises
 Chai.use(ChaiAsPromised);
 
@@ -45,7 +46,14 @@ describe('Sia-UI', function () {
 	describe('on startup', function () {
 		it('opens Sia-UI properly', function () {
 			return client.waitUntilWindowLoaded()
-				.getWindowCount().should.eventually.equal(1)
+				.getWindowCount().then(function(count) {
+					Fs.readdir(Path.join(__dirname, '../plugins'), function(err, plugins) {
+						should.not.exist(err);
+						// Not sure why, but the plugins sometimes register as
+						// part of the Window Count
+						count.should.equal(1 || 1 + plugins.length);
+					});
+				})
 				.isWindowMinimized().should.eventually.be.false
 				.isWindowDevToolsOpened().should.eventually.be.false
 				.isWindowVisible().should.eventually.be.true


### PR DESCRIPTION
These tests are ran by electron-mocha. This is basically the same as mocha except it handles electron-specific requires like `require('browser-window')`. 

Spectron, a node package that combos ChromeDriver with WebDriverIO to run and test electron, is the major addition here. Big kudos to https://github.com/kevinsawicki for his repo.

There is just one test so far. I'm adding more tests in a different branch to be put into a different PR.
