### PR TITLE
Golang no longer a prequisite, got rid of globally required imports

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -80,8 +80,8 @@
 
 	"maxerr"        : 100,      // Maximum errors before stopping.
 	"globals"       : {         // Extra globals.
-		"Plugins": true,
 		/* MOCHA */
+		"Plugins": true,
 		"describe"   : false,
 		"it"         : false,
 		"before"     : false,

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ the Sia network.
 
 ## Prerequisites
 
-- [golang 1.4+](https://golang.org/doc/install) (with a proper GOPATH environment variable)
-	- [Sia](https://github.com/NebulousLabs/Sia) (if not, just run `npm run
-	  sia-repo` after setting up golang)
 - [node & npm (packaged together)](https://nodejs.org/download/)
 
 ## Running
@@ -28,7 +25,6 @@ the Sia network.
 ### OR
 
 Run from source
-* (If you don't have the Sia repo) `npm run sia-repo`
 * `npm install`
 * `npm start`
 

--- a/index.html
+++ b/index.html
@@ -50,26 +50,6 @@
 
 		<!-- Javascript -->
 		<script> 
-			// The following variables occupy the global namespace and should
-			// be limited to what's absolutely necessary
-
-			// Imported Electron modules
-			const Electron = require('electron');
-			const IPCRenderer = Electron.ipcRenderer;
-			const WebFrame = Electron.webFrame;
-			const ElectronScreen = Electron.screen;
-			const Shell = Electron.shell;
-			const Remote = Electron.remote;
-			const mainWindow = Remote.getCurrentWindow();
-
-			// Imported Node modules
-			const Path = require('path');
-			const Fs = require('fs');
-
-			// Imported Node packages
-			const $ = require('jquery');
-			const Siad = require('sia.js');
-
 			// Imported closures that manage the UI
 			var UI = require('./js/uiManager.js');
 			var Plugins = require('./js/pluginManager.js');

--- a/js/.jshintrc
+++ b/js/.jshintrc
@@ -61,7 +61,7 @@
 	"couch"         : false,    // Enable globals exposed by CouchDB.
 	"devel"         : false,    // Allow development statements e.g. `console.log();`.
 	"dojo"          : false,    // Enable globals exposed by Dojo Toolkit.
-	"jquery"        : true ,    // Enable globals exposed by jQuery JavaScript library.
+	"jquery"        : false,    // Enable globals exposed by jQuery JavaScript library.
 	"mootools"      : false,    // Enable globals exposed by MooTools JavaScript framework.
 	"node"          : true,     // Enable globals available when code is running inside of the NodeJS runtime environment.
 	"nonstandard"   : false,    // Define non-standard but widely adopted globals such as escape and unescape.
@@ -80,18 +80,8 @@
 
 	"maxerr"        : 100,      // Maximum errors before stopping.
 	"globals"       : {         // Extra globals.
-		/* Global Libraries */
-		"Electron": false,
-		"Path": false,
-		"WebFrame": false,
-		"ElectronScreen": false,
-		"Fs": false,
-		"Shell": false,
-		"Remote": false,
-		"mainWindow": true,
 		/* UI globals */
 		"UI": true,
-		"Siad": true,
 		"Plugins": true
 	},
 	"indent"        : 4         // Specify indentation spacing

--- a/js/justGetSia.js
+++ b/js/justGetSia.js
@@ -1,0 +1,8 @@
+'use strict';
+
+// This script, much like how the name says, downloads a Sia release into the
+// UI's root directory.
+const SiadWrapper = require('sia.js');
+const Path = require('path')
+
+SiadWrapper.download(Path.join(__dirname, '..', 'Sia'));

--- a/js/justGetSia.js
+++ b/js/justGetSia.js
@@ -3,6 +3,6 @@
 // This script, much like how the name says, downloads a Sia release into the
 // UI's root directory.
 const SiadWrapper = require('sia.js');
-const Path = require('path')
+const Path = require('path');
 
 SiadWrapper.download(Path.join(__dirname, '..', 'Sia'));

--- a/js/plugin.js
+++ b/js/plugin.js
@@ -1,7 +1,9 @@
 'use strict';
 
 // Plugin Factory namespace to hold plugin creation logic
-var Factory = require('./pluginFactory');
+const Factory = require('./pluginFactory');
+// Node module
+const Path = require('path');
 
 /**
  * Constructs the webview and button from a plugin folder

--- a/js/pluginFactory.js
+++ b/js/pluginFactory.js
@@ -49,7 +49,7 @@ module.exports = {
 
 		// Have all plugins displaying UI's zoom by default
 		v.addEventListener('dom-ready', function() {
-			var zoomCode = 'require("web-frame").setZoomFactor(' + WebFrame.getZoomFactor() + ');';
+			var zoomCode = 'require("electron").webFrame.setZoomFactor(' + require('electron').webFrame.getZoomFactor() + ');';
 			v.executeJavaScript(zoomCode);
 		});
 

--- a/js/pluginManager.js
+++ b/js/pluginManager.js
@@ -1,5 +1,11 @@
 'use strict';
 
+// Imported Node modules
+const Path = require('path');
+const Fs = require('fs');
+// Imported Other modules
+const $ = require('jquery');
+
 /**
  * PluginManager manages all plugin logic for the UI
  * @class PluginManager

--- a/js/uiConfig.js
+++ b/js/uiConfig.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Node module
+const Path = require('path');
+const Fs = require('fs');
 /** 
  * The default settings 
  * @private

--- a/js/uiManager.js
+++ b/js/uiManager.js
@@ -248,7 +248,7 @@ module.exports = (function UIManager() {
 
 			// Initialize other manager classes
 			Plugins.init(config);
-			Siad.configure(config);
+			Siad.configure(config.siad);
 
 			// Listen for siad events and notify accordingly
 			addSiadListeners();

--- a/js/uiManager.js
+++ b/js/uiManager.js
@@ -1,5 +1,15 @@
 'use strict';
 
+// Imported Electron modules
+const Electron = require('electron');
+const mainWindow = Electron.remote.getCurrentWindow();
+// Imported Node modules
+const Path = require('path');
+const Fs = require('fs');
+// Imported Other modules
+const Siad = require('sia.js');
+const $ = require('jquery');
+
 /**
  * The first renderer process, handles initializing all other managers
  * @class UIManager
@@ -208,7 +218,7 @@ module.exports = (function UIManager() {
 
 				// If not, provide links to UI release page
 				var updatePage = function() {
-					Shell.openExternal('https://github.com/NebulousLabs/Sia-UI/releases');
+					Electron.shell.openExternal('https://github.com/NebulousLabs/Sia-UI/releases');
 				};
 				$('#update-ui').show().click(updatePage);
 				notify('Update available for UI', 'update', updatePage);

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "sia-kill": "killall siad; while pgrep siad; do sleep .5; done;",
     "sia-refresh": "npm run sia-kill && rm -rf Sia && npm run sia-import",
     "release-args": "electron-packager . Sia-UI --app-version=0.4.8-beta --version=0.34.1 --overwrite --prune --ignore=release --out=release/v0.4.8-beta --icon=app/assets/icon",
-    "release": "npm run sia-import ; npm run release-args -- --all && ./.finalizeRelease.sh",
-    "release-lin64": "npm run release-args -- --platform=linux --arch=x64 && ./.finalizeRelease.sh",
-    "release-lin32": "npm run release-args -- --platform=linux --arch=ia32 && ./.finalizeRelease.sh",
-    "release-win64": "npm run release-args -- --platform=win32 --arch=x64 && ./.finalizeRelease.sh",
-    "release-win32": "npm run release-args -- --platform=win32 --arch=ia32 && ./.finalizeRelease.sh",
-    "release-mac": "npm run release-args -- --platform=darwin --arch=x64 && ./.finalizeRelease.sh"
+    "release": "npm run release-args -- --all && ./.finalizeRelease.sh all",
+    "release-lin64": "npm run release-args -- --platform=linux --arch=x64 && ./.finalizeRelease.sh linux-x64",
+    "release-lin32": "npm run release-args -- --platform=linux --arch=ia32 && ./.finalizeRelease.sh linux-ia32",
+    "release-win64": "npm run release-args -- --platform=win32 --arch=x64 && ./.finalizeRelease.sh win32-x64",
+    "release-win32": "npm run release-args -- --platform=win32 --arch=ia32 && ./.finalizeRelease.sh wi32-ia32",
+    "release-mac": "npm run release-args -- --platform=darwin --arch=x64 && ./.finalizeRelease.sh darwin-x64"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "doc": "jsdoc -c .jsdocrc",
     "sia-repo": "go get -u github.com/NebulousLabs/Sia/...",
     "sia-import": "(test -d Sia || mkdir -p Sia) && (cp $GOPATH/bin/siad Sia & cp $GOPATH/bin/siac Sia)",
+    "sia-download": "node js/justGetSia.js",
+    "postinstall": "npm run sia-download",
     "sia-kill": "killall siad; while pgrep siad; do sleep .5; done;",
     "sia-refresh": "npm run sia-kill && rm -rf Sia && npm run sia-import",
     "release-args": "electron-packager . Sia-UI --app-version=0.4.8-beta --version=0.34.1 --overwrite --prune --ignore=release --out=release/v0.4.8-beta --icon=app/assets/icon",


### PR DESCRIPTION
Various changes that _seem_ unrelated but actually are. Explanation in chronological order:
- Fixed `.finalizeRelease.sh` as it wasn't putting the correct Sia release into each Sia-UI release before
  - This took a bunch of inspiration from David's previous release.sh code
- From there I saw that Golang wasn't needed for anything else besides `npm run sia-import` and so I added `justGetSia.js` to download sia on post-install instead of relying on the user to have a `$GOPATH/bin/siad`
- Fixed bug with how `siad.configure` was being called. Irrelevant with #155 but twas a quick fix.
- Because jshint was complaining about the `justGetSia.js` redefinition of the globally require 'path' node library, I got rid of global imports on the general UI level. They seemed like more trouble than they were worth anyway.
