### PR TITLE
Facilitate a config.siad.detached option

### DIFF
--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -5,6 +5,7 @@ const defaultConfig = {
 	homePlugin:  'Overview',
 	siad: {
     	path: require('path').join(__dirname, '../..', 'Sia'),
+		detached: false,
 	},
 	width:       800,
 	height:      600,

--- a/js/mainjs/initSiad.js
+++ b/js/mainjs/initSiad.js
@@ -131,9 +131,8 @@ function checkSiadPath() {
 		if (!siadPath) {
 			checkSiadPath();
 		} else if (selected === 0) {
-			var lastIndex = siadPath.lastIndexOf('/');
-			config.siad.command = siadPath.substring(lastIndex);
-			config.siad.path = siadPath.substring(0, lastIndex);
+			config.siad.fileName = Path.basename(siadPath);
+			config.siad.path = Path.dirname(siadPath);
 			checkSiadPath();
 		} else if (selected === 1) {
 			config.siad.path = siadPath;
@@ -160,7 +159,9 @@ module.exports = function initSiad(cnfg, mW) {
 	// child process of electron, forcing electron to keep running until siad
 	// has stopped
 	mainWindow.on('close', function() {
-		Siad.stop();
+		if (!config.siad.detached) {
+			Siad.stop();
+		}
 	});
 
 	// Set config for Siad to work off of configure() doesn't update


### PR DESCRIPTION
Not only will some users/devs want siad as a detached process, but it
allows easier and faster debugging since one won't have to wait siad to
load every time

Corresponds to https://github.com/NebulousLabs/Nodejs-Sia/pull/14
**NOTE**: the Nodejs-Sia PR should be accepted first, version bumped, and then published before this PR can actually utilize those changes.
