### PR TITLE
Files plugin fixes/adaptation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Sia</title>
+		<title>Sia-UI</title>
 		<!-- Stylesheets -->
 		<link rel='stylesheet' href='css/font-awesome.min.css'>
 		<link rel='stylesheet' href='css/pure-min.css'>

--- a/plugins/About/index.html
+++ b/plugins/About/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<title>About</title>
 		<!-- CSS -->
 		<link rel="stylesheet" href="../../css/roboto-condensed-min.css">
 		<link rel="stylesheet" href="../../css/font-awesome.min.css">

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -36,7 +36,14 @@ input {
 
 /* Current Directory Path */
 .directory {
+	border: 1px solid #F5F5F5;
 	vertical-align: middle;
+	-webkit-animation: fadein 0.3s;
+}
+.directory:hover {
+	border: 1px solid #DDDDDD;
+	-webkit-box-shadow: inset 0 0 3px #ECECEC;
+	-webkit-animation: fadein 0.3s;
 }
 .button {
 	display: inline-block;

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -129,17 +129,21 @@ hr {
 }
 .file .name {
 	text-align: left;
-	max-width: calc(100% - 215px);
+	max-width: calc(100% - 210px);
 	white-space: nowrap;
 }
-.file .size {
+.file .info {
 	float: right;
+}
+.file .info > * {
+	display: inline-block;
+}
+.file .size {
 	text-align: right;
 	width: 60px;
 	margin-right: 10px;
 }
 .file .detail {
-	float: right;
 	text-align: left;
 	width: 120px;
 }

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -129,15 +129,17 @@ hr {
 }
 .file .name {
 	text-align: left;
-	width: calc(100% - 250px);
+	max-width: calc(100% - 250px);
 	overflow: hidden;
 	white-space: nowrap;
 }
 .file .size {
+	float: right;
 	text-align: right;
 	width: 75px;
 }
-.file .time {
+.file .detail {
+	float: right;
 	text-align: center;
 	width: 150px;
 }

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -129,19 +129,19 @@ hr {
 }
 .file .name {
 	text-align: left;
-	max-width: calc(100% - 250px);
-	overflow: hidden;
+	max-width: calc(100% - 215px);
 	white-space: nowrap;
 }
 .file .size {
 	float: right;
 	text-align: right;
-	width: 75px;
+	width: 60px;
+	margin-right: 10px;
 }
 .file .detail {
 	float: right;
-	text-align: center;
-	width: 150px;
+	text-align: left;
+	width: 120px;
 }
 .cssTooltip {
 	display: inline;

--- a/plugins/Files/index.html
+++ b/plugins/Files/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<title>Files</title>
 		<!-- CSS -->
 		<link rel='stylesheet' href='../../css/roboto-condensed-min.css'>
 		<link rel='stylesheet' href='../../css/font-awesome.min.css'>

--- a/plugins/Files/index.html
+++ b/plugins/Files/index.html
@@ -16,7 +16,7 @@
 				<div class='title'>Files</div>
 				<div class='capsule'>
 					<div class='pod button' id='host-count'>
-						<i class='fa fa-globe'></i>
+						<i class='fa fa-users'></i>
 						<span></span>
 					</div>
 					<div class='pod' id='price'></div>

--- a/plugins/Files/index.html
+++ b/plugins/Files/index.html
@@ -84,12 +84,11 @@
 
 				<!-- File list for current folder -->
 				<div class='file label'>
-					<div class='graphic'>
-						<i class='fa'></i>
-					</div>
 					<div class='name'>Name</div>
-					<div class='detail'>Detail</div>
-					<div class='size'>Size</div>
+					<div class='info'>
+						<div class='size'>Size</div>
+						<div class='detail'>Detail</div>
+					</div>
 				</div>
 				<div id='file-list'>
 				</div>

--- a/plugins/Files/index.html
+++ b/plugins/Files/index.html
@@ -88,8 +88,8 @@
 						<i class='fa'></i>
 					</div>
 					<div class='name'>Name</div>
+					<div class='detail'>Detail</div>
 					<div class='size'>Size</div>
-					<div class='time'>Time</div>
 				</div>
 				<div id='file-list'>
 				</div>

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -113,12 +113,25 @@ function updateCWD(navigateTo) {
 	folders.push(currentFolder);
 
 	// Add a directory element per folder
-	folders.forEach(function(f) {
+	folders.forEach(function(f, i) {
 		var el = $(`
 			<span class='button directory' id='dir-${f.path}'>
-				${f.name}/
 			</span>
 		`);
+		// Root folder
+		if (f.path === '') {
+			el.html('<i class=\'fa fa-folder\'></i>');
+		} else {
+			// Middle folders
+			el.html(f.name);
+		}
+
+		// Last folder
+		if (i === folders.length - 1) {
+			el.append(' <i class=\'fa fa-caret-down\'></i>');
+		} else {
+			el.append('/');
+		}
 
 		// Clicking the element navigates to that folder
 		el.click(function() {
@@ -127,9 +140,6 @@ function updateCWD(navigateTo) {
 
 		// Append and add icon for root folder
 		cwd.append(el);
-		if (f.path === '') {
-			el.prepend('<i class=\'fa fa-folder\'></i>');
-		}
 	});
 
 	// Sum up widths to move dropdown right as directory is deeper
@@ -140,7 +150,7 @@ function updateCWD(navigateTo) {
 	});
 
 	// New file/folder button appears below last folder
-	cwd.children().last().click(function() {
+	cwd.children().last().off('click').click(function() {
 		var dropdown = $('.hidden.dropdown');
 		dropdown.css('left', cwdLength + 'px');
 		dropdown.toggle('fast');

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -51,7 +51,7 @@ function getSelectedElements() {
 
 // Returns selected files/folders from currentFolder
 function getSelectedFiles() {
-	return getSelectedElements().map(el => currentFolder.contents[el.id]);
+	return getSelectedElements().map(el => currentFolder.files[el.id]);
 }
 
 // Refresh the file list according to the currentFolder
@@ -64,16 +64,16 @@ function updateList(navigateTo) {
 	// track untouched elements (indicates removal is needed) in an object and
 	// remove if updated or created
 	list.empty();
-	currentFolder.contentsArray.forEach(content => {
+	currentFolder.filesArray.forEach(file => {
 		var el;
-		if (content.type === 'file') {
+		if (file.type === 'file') {
 			// Make and display a file element
-			el = fileElement(content);
-		} else if (content.type === 'folder') {
+			el = fileElement(file);
+		} else if (file.type === 'folder') {
 			// Make and display a folder element
-			el = folderElement(content, navigateTo);
+			el = folderElement(file, navigateTo);
 		} else {
-			console.error('Unknown file type: ' + content.type, content);
+			console.error('Unknown file type: ' + file.type, file);
 		}
 		list.append(el);
 	});
@@ -93,15 +93,15 @@ function updateFile(result) {
 	var folderIterator = rootFolder;
 	fileFolders.forEach(function(folderName) {
 		// Continue to next folder or make folder if it doesn't already exist
-		folderIterator = folderIterator.contents[folderName] ? folderIterator.contents[folderName] : folderIterator.addFolder(folderName);
+		folderIterator = folderIterator.files[folderName] ? folderIterator.files[folderName] : folderIterator.addFolder(folderName);
 	});
 
 	// Make file if needed
-	if (!folderIterator.contents[fileName]) {
+	if (!folderIterator.files[fileName]) {
 		folderIterator.addFile(result);
 	} else {
 		// Update the stats on the file object
-		folderIterator.contents[fileName].update(result);
+		folderIterator.files[fileName].update(result);
 	}
 }
 
@@ -344,9 +344,9 @@ var browser = {
 	makeFolder () {
 		var name = 'New Folder';
 		// Ensure unique name
-		if (currentFolder.contents[name]) {
+		if (currentFolder.files[name]) {
 			var n = 0;
-			while (currentFolder.contents[`${name}_${n}`]) {
+			while (currentFolder.files[`${name}_${n}`]) {
 				n++;
 			}
 			name = `${name}_${n}`;

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -86,7 +86,7 @@ function updateList(navigateTo) {
 
 // Update file from api result
 function updateFile(result) {
-	var fileFolders = result.nickname.split('/');
+	var fileFolders = result.siapath.split('/');
 	var fileName = fileFolders.pop();
 
 	// Make any needed folders

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -355,17 +355,11 @@ var browser = {
 
 		// Setup async calls to each file to download them
 		tools.notify(`Downloading ${label} to ${destination}`, 'download');
-		if (itemCount === 1) {
-			files[0].download(destination, function() {
-				tools.notify(`Downloaded {label} to ${destination}`, 'success');
-			});
-		} else {
-			let functs = files.map(file => file.download);
+			let functs = files.map(file => file.download.bind(file));
 			let destinations = files.map(file => `${destination}/${file.name}`);
 			tools.waterfall(functs, destinations, function() {
-				tools.notify(`Downloaded {label} to ${destination}`, 'success');
+				tools.notify(`Downloaded ${label} to ${destination}`, 'success');
 			});
-		}
 	},
 
 	// Filter file list by search string

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -60,6 +60,9 @@ function updateList(navigateTo) {
 	var list = $('#file-list');
 
 	// Refresh the list
+	// TODO: Don't empty list, update elements and add new elements if needed,
+	// track untouched elements (indicates removal is needed) in an object and
+	// remove if updated or created
 	list.empty();
 	currentFolder.contentsArray.forEach(content => {
 		var el;

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -149,6 +149,23 @@ function updateCWD(navigateTo) {
 
 // The browser object
 var browser = {
+	// Update files in the browser
+	update () {
+		// TODO: This call doesn't always include a file added right before the
+		// call to this function. Waiting 100ms provides a not-noticeable delay and
+		// allows siad time to provide an up to date list, but is flawed
+		setTimeout(function() {
+			siad.apiCall('/renter/files', function(results) {
+				// Update the current working directory
+				updateCWD(browser.navigateTo);
+				// Add or update each file from a `renter/files/list` call
+				results.files.forEach(updateFile);
+				// Update the file list
+				updateList(browser.navigateTo);
+			});
+		}, 100);
+	},
+
 	// Expose these, mostly for debugging purposes
 	get currentFolder () {
 		return currentFolder;
@@ -252,10 +269,13 @@ var browser = {
 		}
 
 		// Save file/folder into specific place
-		var destination = tools.dialog('save', {
+		var dialogOptions = {
 			title:       'Download ' + label,
-			defaultPath: label,
-		});
+		};
+		if (itemCount === 1) {
+			dialogOptions.defaultPath = label;
+		}
+		var destination = tools.dialog('save', dialogOptions);
 
 		// Ensure destination exists
 		if (!destination) {
@@ -268,23 +288,6 @@ var browser = {
 		tools.waterfall(functs, destination, function() {
 			tools.notify(`Downloaded {label} to ${destination}`, 'success');
 		});
-	},
-
-	// Update files in the browser
-	update () {
-		// TODO: This call doesn't always include a file added right before the
-		// call to this function. Waiting 100ms provides a not-noticeable delay and
-		// allows siad time to provide an up to date list, but is flawed
-		setTimeout(function() {
-			siad.apiCall('/renter/files', function(results) {
-				// Update the current working directory
-				updateCWD(browser.navigateTo);
-				// Add or update each file from a `renter/files/list` call
-				results.files.forEach(updateFile);
-				// Update the file list
-				updateList(browser.navigateTo);
-			});
-		}, 100);
 	},
 
 	// Filter file list by search string

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -13,8 +13,8 @@ const $ = require('jquery');
 const siad = require('sia.js');
 const tools = require('./uiTools');
 const fileElement = require('./fileElement');
-const loader = require('./loader');
 const folderElement = require('./folderElement');
+const loader = require('./loader');
 
 // Root folder object to hold all other file and folder objects
 var rootFolder = require('./folderFactory')('');

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -417,14 +417,26 @@ var browser = {
 browser['Make Folder'] = browser.makeFolder;
 browser['Upload File'] = function uploadFiles(filePaths, callback) {
 	// Files upload to currentFolder.path/name by default
-	tools.waterfall(loader.uploadFile, filePaths, currentFolder.path, callback);
+	tools.notify(`Uploading ${filePaths.length} file(s)!`, 'upload');
+	tools.waterfall(loader.uploadFile, filePaths, currentFolder.path, function() {
+		tools.notify(`Upload for ${filePaths.length} file(s) completed!`, 'success');
+		callback();
+	});
 };
 browser['Upload Folder'] = function uploadFolders(dirPaths, callback) {
 	// Uploads to currentFolder.path/name, keeping their original structure
-	tools.waterfall(loader.uploadFolder, dirPaths, currentFolder.path, callback);
+	tools.notify(`Uploading ${dirPaths.length} folder(s)!`, 'upload');
+	tools.waterfall(loader.uploadFolder, dirPaths, currentFolder.path, function() {
+		tools.notify(`Upload for ${dirPaths.length} folder(s) completed!`, 'success');
+		callback();
+	});
 };
 browser['Load .Sia File'] = function loadDotSias(filePaths, callback) {
-	tools.waterfall(loader.loadDotSia, filePaths, callback);
+	tools.notify(`Loading ${filePaths.length} .sia file(s)!`, 'siafile');
+	tools.waterfall(loader.loadDotSia, filePaths, function() {
+		tools.notify(`Loaded ${filePaths.length} .sia(s) file(s)!`, 'success');
+		callback();
+	});
 };
 browser['Load ASCII File'] = loader.loadAscii;
 

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -72,7 +72,7 @@ function updateList(navigateTo) {
 	var files = currentFolder.filesArray;
 	var hashes = files.map(file => file.hashedPath);
 	$('.file:not(.label)').each(function() {
-		if (hashes.indexOf(this.id) === -1) {
+		if (!hashes.includes(this.id)) {
 			$(this).remove();
 		}
 	});
@@ -378,7 +378,7 @@ var browser = {
 	// TODO: only searches the current folder for now
 	filter (searchstr) {
 		$('#file-list').children().each(function(entry) {
-			if ($(this).find('.name').html().indexOf(searchstr) > -1) {
+			if ($(this).find('.name').text().includes(searchstr)) {
 				entry.show();
 			} else {
 				entry.hide();

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -41,6 +41,17 @@ function selectAnchor(el) {
 	el.addClass('selected');
 }
 
+// Show action buttons iff there are selected files
+function checkActionButtons() {
+	var someSelected = $('.selected').length;
+	var buttonsAreVisible = $('.controls .button').is(':visible');
+	if (someSelected && !buttonsAreVisible) {
+		$('.controls .button').fadeIn('fast');
+	} else if (!someSelected && buttonsAreVisible) {
+		$('.controls .button').fadeOut('fast');
+	}
+}
+
 // Returns selected elements from current file list
 function getSelectedElements() {
 	// Get array of selected element's names (same as their ids)
@@ -160,7 +171,7 @@ function updateCWD(navigateTo) {
 // The browser object
 var browser = {
 	// Update files in the browser
-	update () {
+	update (callback) {
 		// TODO: This call doesn't always include a file added right before the
 		// call to this function. Waiting 100ms provides a not-noticeable delay and
 		// allows siad time to provide an up to date list, but is flawed
@@ -172,8 +183,11 @@ var browser = {
 				results.files.forEach(updateFile);
 				// Update the file list
 				updateList(browser.navigateTo);
+				if (callback) {
+					callback();
+				}
 			});
-		}, 100);
+		}, 50);
 	},
 
 	// Expose these, mostly for debugging purposes
@@ -187,6 +201,7 @@ var browser = {
 	// Select an item in the current folder
 	select (el) {
 		selectAnchor(el);
+		checkActionButtons();
 	},
 	toggle (el) {
 		deselectAnchor();
@@ -194,6 +209,7 @@ var browser = {
 		if (el.hasClass('selected')) {
 			selectAnchor(el);
 		}
+		checkActionButtons();
 	},
 
 	// Select items from the last selected file to the one passed in
@@ -210,18 +226,21 @@ var browser = {
 				el.nextUntil(anchor).addClass('selected');
 			}
 		}
+		checkActionButtons();
 	},
 
 	// Select all items in the current folder
 	selectAll () {
 		deselectAnchor();
 		$('#file-list .file').addClass('selected');
+		checkActionButtons();
 	},
 
 	// Deselect all items in the current folder
 	deselectAll () {
 		deselectAnchor();
 		$('#file-list .file').removeClass('selected');
+		checkActionButtons();
 	},
 
 	// Deletes selected files
@@ -341,7 +360,7 @@ var browser = {
 	},
 
 	// Makes a new folder element temporarily
-	makeFolder () {
+	makeFolder (userInput, callback) {
 		var name = 'New Folder';
 		// Ensure unique name
 		if (currentFolder.files[name]) {
@@ -354,6 +373,9 @@ var browser = {
 		var folder = currentFolder.addFolder(name);
 		var element = folderElement(folder, browser.navigateTo);
 		$('#file-list').append(element);
+		if (callback) {
+			callback();
+		}
 	},
 };
 

--- a/plugins/Files/js/file.js
+++ b/plugins/Files/js/file.js
@@ -24,14 +24,14 @@ var file = {
 			return;
 		}
 		Object.assign(this, stats);
-		this.path = stats.nickname;
+		this.path = stats.siapath;
 	},
 
 	// The below are just function forms of the renter calls a file can enact
 	// on itself, see the API.md
 	// https://github.com/NebulousLabs/Sia/blob/master/doc/API.md#renter
 
-	// Changes file's nickname with siad call
+	// Changes file's siapath with siad call
 	setPath (newPath, callback) {
 		if (tools.notType(newPath, 'string')) {
 			return;

--- a/plugins/Files/js/file.js
+++ b/plugins/Files/js/file.js
@@ -62,6 +62,7 @@ var file = {
 		});
 	},
 	delete (callback) {
+		console.log(this.path)
 		siad.apiCall({
 			url: '/renter/delete/' + this.path,
 			method: 'POST',

--- a/plugins/Files/js/file.js
+++ b/plugins/Files/js/file.js
@@ -25,6 +25,7 @@ var file = {
 		}
 		Object.assign(this, stats);
 		this.path = stats.siapath;
+		return this;
 	},
 
 	// Get array of folder objects that contain this particular file
@@ -110,6 +111,10 @@ var file = {
 		// path of 'foo/bar/baz' would return 'baz'
 		return path.basename(this.path);
 	},
+	get pathArray () {
+		// path of 'foo/bar/baz' would return ['foo', 'bar', 'baz]
+		return this.path.split('/');
+	},
 	get directory () {
 		// path of 'foo/bar/baz' would return 'foo/bar'
 		var directory = path.dirname(this.path);
@@ -125,6 +130,12 @@ var file = {
 	},
 	get nameNoExtension () {
 		return path.basename(this.path, this.extension);
+	},
+	// Since spaces, chinese characters, etc. are allowable in file names but
+	// not in html ids, hashedPath() gets a unique representations of files that
+	// is html id friendly
+	get hashedPath() {
+		return require('crypto').createHash('md5').update(this.path).digest('hex');
 	},
 
 	// These can't use set syntax because they're necessarily asynchronous

--- a/plugins/Files/js/file.js
+++ b/plugins/Files/js/file.js
@@ -62,7 +62,6 @@ var file = {
 		});
 	},
 	delete (callback) {
-		console.log(this.path)
 		siad.apiCall({
 			url: '/renter/delete/' + this.path,
 			method: 'POST',

--- a/plugins/Files/js/file.js
+++ b/plugins/Files/js/file.js
@@ -109,7 +109,11 @@ var file = {
 	// Path related functions
 	get name () {
 		// path of 'foo/bar/baz' would return 'baz'
-		return path.basename(this.path);
+		if (this.path.slice(-1) === '/') {
+			return '';
+		} else {
+			return path.basename(this.path);
+		}
 	},
 	get pathArray () {
 		// path of 'foo/bar/baz' would return ['foo', 'bar', 'baz]
@@ -117,9 +121,7 @@ var file = {
 	},
 	get directory () {
 		// path of 'foo/bar/baz' would return 'foo/bar'
-		var directory = path.dirname(this.path);
-		// Prevent path.dirname from returning '.'
-		return (directory === '.' ? '' : directory);
+		return this.pathArray.slice(0, -1).join('/');
 	},
 	get folderNames () {
 		// path of 'foo/bar/baz' would return ['foo', 'bar']
@@ -143,21 +145,24 @@ var file = {
 		if (tools.notType(newName, 'string')) {
 			return;
 		}
-		var newPath = `${this.directory}/${newName}`;
+		var d = this.directory;
+		var newPath = d === '' ? newName : `${d}/${newName}`;
 		this.setPath(newPath, cb);
 	},
 	setDirectory (newDirectory, cb) {
 		if (tools.notType(newDirectory, 'string')) {
 			return;
 		}
-		var newPath = `${newDirectory}/${this.name}`;
+		var newPath = newDirectory === '' ? this.name : `${newDirectory}/${this.name}`;
 		this.setPath(newPath, cb);
 	},
 	setExtension (newExtension, cb) {
 		if (tools.notType(newExtension, 'string')) {
 			return;
 		}
-		var newPath = `${this.directory}/${this.nameNoExtension}${newExtension}`;
+		var d = this.directory;
+		var newPath = d === '' ? '' : d + '/';
+		newPath = newPath + this.nameNoExtension + newExtension;
 		this.setPath(newPath, cb);
 	},
 };

--- a/plugins/Files/js/file.js
+++ b/plugins/Files/js/file.js
@@ -10,6 +10,7 @@
 const path = require('path');
 const $ = require('jquery');
 const siad = require('sia.js');
+const tools = require('./uiTools');
 
 var file = {
 	// Properties every file should have
@@ -19,6 +20,9 @@ var file = {
 
 	// Update/record file stats
 	update (stats) {
+		if (tools.notType(stats, 'object')) {
+			return;
+		}
 		Object.assign(this, stats);
 		this.path = stats.nickname;
 	},
@@ -29,8 +33,7 @@ var file = {
 
 	// Changes file's nickname with siad call
 	setPath (newPath, callback) {
-		if (typeof newPath !== 'string') {
-			console.error('Improper argument!', newPath);
+		if (tools.notType(newPath, 'string')) {
 			return;
 		}
 		siad.apiCall({
@@ -56,8 +59,7 @@ var file = {
 		});
 	},
 	download (destination, callback) {
-		if (typeof destination !== 'string') {
-			console.error('Improper argument!', destination);
+		if (tools.notType(destination, 'string')) {
 			return;
 		}
 		siad.apiCall({
@@ -68,8 +70,10 @@ var file = {
 		}, callback);
 	},
 	share (destination, callback) {
-		if (typeof destination !== 'string' || destination.slice(-4) !== '.sia') {
-			console.error('Improper argument!', destination);
+		if (tools.notType(destination, 'string')) {
+			return;
+		} else if (destination.slice(-4) !== '.sia') {
+			console.error('Share path needs end in ".sia"!', destination);
 			return;
 		}
 		siad.apiCall({
@@ -110,24 +114,26 @@ var file = {
 	get nameNoExtension () {
 		return path.basename(this.path, this.extension);
 	},
-	get size () {
-		// Returns the attribute given to file objects from `/renter/files`
-		return this.filesize;
-	},
-	get count () {
-		return 1;
-	},
 
 	// These can't use set syntax because they're necessarily asynchronous
 	setName (newName, cb) {
+		if (tools.notType(newName, 'string')) {
+			return;
+		}
 		var newPath = `${this.directory}/${newName}`;
 		this.setPath(newPath, cb);
 	},
 	setDirectory (newDirectory, cb) {
+		if (tools.notType(newDirectory, 'string')) {
+			return;
+		}
 		var newPath = `${newDirectory}/${this.name}`;
 		this.setPath(newPath, cb);
 	},
 	setExtension (newExtension, cb) {
+		if (tools.notType(newExtension, 'string')) {
+			return;
+		}
 		var newPath = `${this.directory}/${this.nameNoExtension}${newExtension}`;
 		this.setPath(newPath, cb);
 	},

--- a/plugins/Files/js/file.js
+++ b/plugins/Files/js/file.js
@@ -66,7 +66,7 @@ var file = {
 			url: '/renter/delete/' + this.path,
 			method: 'POST',
 		}, result => {
-			delete this.parentFolder.contents[this.name];
+			delete this.parentFolder.files[this.name];
 			callback(result);
 		});
 	},

--- a/plugins/Files/js/file.js
+++ b/plugins/Files/js/file.js
@@ -27,6 +27,18 @@ var file = {
 		this.path = stats.siapath;
 	},
 
+	// Get array of folder objects that contain this particular file
+	get parentFolders () {
+		// path of 'foo/bar/baz' would return folder objects whose paths are
+		// 'foo' and 'foo/bar' respectively
+		var parentFolders = [];
+		// iterate through parentFolder links to populate parentFolders
+		for (let i = this.parentFolder; i; i = i.parentFolder) {
+			parentFolders.push(i);
+		}
+		return parentFolders.reverse();
+	},
+
 	// The below are just function forms of the renter calls a file can enact
 	// on itself, see the API.md
 	// https://github.com/NebulousLabs/Sia/blob/master/doc/API.md#renter
@@ -136,18 +148,6 @@ var file = {
 		}
 		var newPath = `${this.directory}/${this.nameNoExtension}${newExtension}`;
 		this.setPath(newPath, cb);
-	},
-
-	// Misc. functions
-	get parentFolders () {
-		// path of 'foo/bar/baz' would return folder objects whose paths are
-		// ['foo', 'foo/bar'] respectively
-		var parentFolders = [];
-		// iterate through parentFolder links to populate parentFolders
-		for (let i = this.parentFolder; i; i = i.parentFolder) {
-			parentFolders.push(i);
-		}
-		return parentFolders.reverse();
 	},
 };
 

--- a/plugins/Files/js/fileElement.js
+++ b/plugins/Files/js/fileElement.js
@@ -15,12 +15,15 @@ const tools = require('./uiTools');
 function makeFileElement(f) {
 	var el = $(`
 		<div class='file' id='${f.name}'>
-			<div class='graphic'>
-				<i class='fa fa-${f.type}'></i>
+			<i class='fa fa-${f.type}'></i>
+			<div class='name'>
+				${f.name}
 			</div>
-			<div class='name button'>${f.name}</div>
-			<div class='detail'></div>
-			<div class='size'>${tools.formatByte(f.filesize)}</div>
+			<i class='button fa fa-pencil'></i>
+			<div class='info'>
+				<div class='size'>${tools.formatByte(f.filesize)}</div>
+				<div class='detail'></div>
+			</div>
 		</div>
 	`);
 
@@ -76,10 +79,28 @@ function makeFileElement(f) {
 	});
 	*/
 
-	// Allow user to rename the file
-	el.find('.name.button').click(function() {
-		this.contentEditable = true;
-		$(this).focus();
+	// Double clicking a file prompts to download
+	el.dblclick(function() {
+		// Save file/folder into specific place
+		var destination = tools.dialog('save', {
+			title:       'Download ' + f.name,
+			defaultPath: f.name,
+		});
+
+		// Ensure destination exists
+		if (!destination) {
+			return;
+		}
+
+		tools.notify(`Downloading ${f.name} to ${destination}`, 'download');
+		f.download(destination, function() {
+			tools.notify(`Downloaded {f.name} to ${destination}`, 'success');
+		});
+	}).find('.fa-pencil.button').click(function() {
+		// Allow user to rename the file
+		var name = $(this).prev();
+		name.attr('contentEditable', true);
+		name.focus();
 	}).keypress(function(e) {
 		var field = $(this);
 		var newName = field.text();

--- a/plugins/Files/js/fileElement.js
+++ b/plugins/Files/js/fileElement.js
@@ -41,6 +41,7 @@ function makeFileElement(f) {
 	el.find('.time').text(timeText);
 
 	// Share button, when clicked, asks to download a .sia or copy an ascii
+	/* TODO: move to browser for aggregate action
 	el.find('.share').click(function() {
 		// Present option between .Sia or ASCII method of sharing
 		var option = tools.dialog('message', {
@@ -71,6 +72,7 @@ function makeFileElement(f) {
 			});
 		}
 	});
+	*/
 
 	// Allow user to rename the file
 	el.find('.name.button').click(function() {

--- a/plugins/Files/js/fileElement.js
+++ b/plugins/Files/js/fileElement.js
@@ -19,8 +19,8 @@ function makeFileElement(f) {
 				<i class='fa fa-${f.type}'></i>
 			</div>
 			<div class='name button'>${f.name}</div>
-			<div class='size'>${tools.formatByte(f.filesize)}</div>
 			<div class='detail'></div>
+			<div class='size'>${tools.formatByte(f.filesize)}</div>
 		</div>
 	`);
 

--- a/plugins/Files/js/fileElement.js
+++ b/plugins/Files/js/fileElement.js
@@ -19,8 +19,8 @@ function makeFileElement(f) {
 				<i class='fa fa-${f.type}'></i>
 			</div>
 			<div class='name button'>${f.name}</div>
-			<div class='size'>${tools.formatByte(f.size)}</div>
-			<div class='time'></div>
+			<div class='size'>${tools.formatByte(f.filesize)}</div>
+			<div class='detail'></div>
 		</div>
 	`);
 
@@ -29,16 +29,18 @@ function makeFileElement(f) {
 		el.find('.fa.fa-file').removeClass('fa-file').addClass('fa-refresh fa-spin');
 	}
 
-	// Set time text
-	var timeText;
-	if (f.uploadProgress === 0) {
-		timeText = 'Processing...';
-	} else if (f.uploadProgress < 100) {
-		timeText = f.uploadProgress.toFixed(0) + '%'; 
+	// Set detail text
+	var detailText;
+	if (f.uploadprogress === 0) {
+		detailText = 'Processing...';
+	} else if (f.uploadprogress < 100) {
+		detailText = f.uploadprogress.toFixed(0) + '%'; 
+	} else if (f.renewing) {
+		detailText = 'Renews on block ' + f.expiration;
 	} else {
-		timeText = 'Expires on block ' + f.expiration;
+		detailText = 'Expires on block ' + f.expiration;
 	}
-	el.find('.time').text(timeText);
+	el.find('.detail').text(detailText);
 
 	// Share button, when clicked, asks to download a .sia or copy an ascii
 	/* TODO: move to browser for aggregate action

--- a/plugins/Files/js/fileElement.js
+++ b/plugins/Files/js/fileElement.js
@@ -62,40 +62,6 @@ function makeFileElement(f) {
 	// Populate its fields and graphics
 	updateFileElement(f, el);
 
-	// Share button, when clicked, asks to download a .sia or copy an ascii
-	/* TODO: move to browser for aggregate action
-	el.find('.share').click(function() {
-		// Present option between .Sia or ASCII method of sharing
-		var option = tools.dialog('message', {
-			type:    'question',
-			title:   'Share ' + f.name,
-			message: 'Share via .sia file or ASCII text?',
-			detail:  'Choose to download .sia file or copy ASCII text to clipboard.',
-			buttons: ['.Sia file', 'ASCII text', 'Cancel'],
-		});
-
-		// Choose a location to download the .sia file to
-		if (option === 0) {
-			var destination = tools.dialog('save', {
-				title:       `Share ${f.name}.sia`,
-				defaultPath: f.name + '.sia',
-				filters:     [{ name: 'Sia file', extensions: ['sia'] }],
-			});
-
-			// Download siafile to location
-			f.share(destination, function() {
-				tools.notify(`Put ${f.name}'s .sia files at ${destination}`, 'download');
-			});
-		} else if (option === 1) {
-			// Get the ascii share string
-			f.shareASCII(function(result) {
-				clipboard.writeText(result.file);
-				tools.notify(`Copied ${f.name}.sia to clipboard!`, 'asciifile');
-			});
-		}
-	});
-	*/
-
 	// Double clicking a file prompts to download
 	el.dblclick(function() {
 		// Save file/folder into specific place

--- a/plugins/Files/js/fileFactory.js
+++ b/plugins/Files/js/fileFactory.js
@@ -11,7 +11,7 @@ const file = require('./file');
 // Factory to create instances of the file object
 function fileFactory(arg) {
 	// Files can be constructed from either a nickname or a status object
-	// returned from /renter/list||downloadqueue
+	// returned from /renter/files||downloads
 	var f = Object.create(file);
 	if (typeof arg === 'object'){
 		Object.assign(f, arg);

--- a/plugins/Files/js/fileFactory.js
+++ b/plugins/Files/js/fileFactory.js
@@ -10,12 +10,12 @@ const file = require('./file');
 
 // Factory to create instances of the file object
 function fileFactory(arg) {
-	// Files can be constructed from either a nickname or a status object
+	// Files can be constructed from either a siapath or a status object
 	// returned from /renter/files||downloads
 	var f = Object.create(file);
 	if (typeof arg === 'object'){
 		Object.assign(f, arg);
-		f.path = arg.nickname;
+		f.path = arg.siapath;
 	} else if (typeof arg === 'string') {
 		f.path = arg;
 	} else {

--- a/plugins/Files/js/folder.js
+++ b/plugins/Files/js/folder.js
@@ -223,6 +223,23 @@ var typeError = 'type is neither folder nor file!';
 // The below getters follow the same structure of recursively (bfs) getting
 // data of all files within a folder
 
+// Return one-dimensional array of all files in this folder
+Object.defineProperty(folder, 'filesArrayDeep', {
+	get: function () {
+		var files = [];
+		this.filesArray.forEach(file => {
+			if (file.type === 'folder') {
+				files = files.concat(file.filesArrayDeep);
+			} else if (file.type === 'file') {
+				files.push(file);
+			} else {
+				console.error(typeError, file);
+			}
+		});
+		return files;
+	},
+});
+
 // Calculate sum of file sizes
 Object.defineProperty(folder, 'filesize', {
 	get: function () {
@@ -237,17 +254,7 @@ Object.defineProperty(folder, 'filesize', {
 // Count the number of files
 Object.defineProperty(folder, 'count', {
 	get: function () {
-		var sum = 0;
-		this.filesArray.forEach(file => {
-			if (file.type === 'folder') {
-				sum += file.count;
-			} else if (file.type === 'file') {
-				sum++;
-			} else {
-				console.error(typeError, file);
-			}
-		});
-		return sum;
+		return this.filesArrayDeep.length;
 	},
 });
 
@@ -255,17 +262,7 @@ Object.defineProperty(folder, 'count', {
 // for share and shareascii
 Object.defineProperty(folder, 'paths', {
 	get: function () {
-		var paths = [];
-		this.filesArray.forEach(file => {
-			if (file.type === 'folder') {
-				paths = paths.concat(file.paths);
-			} else if (file.type === 'file') {
-				paths.push(file.path);
-			} else {
-				console.error(typeError, file);
-			}
-		});
-		return paths;
+		return this.filesArrayDeep.map(file => file.path);
 	},
 });
 

--- a/plugins/Files/js/folder.js
+++ b/plugins/Files/js/folder.js
@@ -18,7 +18,12 @@ var folder = Object.assign(Object.create(file), {
 	type: 'folder',
 	contents: {},
 
+	// The below are just function forms of the renter calls a function can
+	// enact on itself, see the API.md
+	// https://github.com/NebulousLabs/Sia/blob/master/doc/API.md#renter
+
 	// Changes folder's and its contents' paths with siad call
+	// TODO: Verify if works
 	setPath (newPath, callback) {
 		var names = this.contentsNames;
 
@@ -36,45 +41,6 @@ var folder = Object.assign(Object.create(file), {
 		});
 	},
 
-	// Add a file
-	addFile (fileObject) {
-		// TODO: verify that the fileObject belongs in this folder
-		var f = fileFactory(fileObject);
-		this.contents[f.name] = f;
-		f.parentFolder = this;
-		return f;
-	},
-
-	// Add a folder, defined after folderFactory() to use it without breaking
-	// strict convention
-	addFolder (name) {
-		// Copy this folder and erase its state to 'create' a new folder
-		// TODO: This seems like an imperfect way to add a new Folder. Can't
-		// use folderFactory function down below because using the folder
-		// factory again seems to return the same folder. Example:
-		//   rootFolder.addFolder('foo') returns a rootFolder with a path of
-		//   'foo' but all the same contents, resulting in circular pointers
-		//   Thus rootFolder.contents === rootFolder.contents.foo.contents
-		var f = Object.create(this);
-		f.path = this.path !== '' ? `${this.path}/${name}` : name;
-		f.contents = {};
-		f.selected = false;
-	
-		// Link new folder to this one and vice versa
-		f.parentFolder = this;
-		this.contents[name] = f;
-		return f;
-	},
-
-	// Return if it's an empty folder
-	isEmpty () {
-		return this.contentsNames.length === 0;
-	},
-
-	// The below are just function forms of the renter calls a function can
-	// enact on itself, see the API.md
-	// https://github.com/NebulousLabs/Sia/blob/master/doc/API.md#renter
-	
 	// Recursively delete folder and its contents
 	delete (callback) {
 		// Make array of each content's delete function
@@ -105,8 +71,19 @@ var folder = Object.assign(Object.create(file), {
 		tools.waterfall(functs, names, callback);
 	},
 
-	// Share .sia files into folder at destination with same structure
+	// Share .sia files of all contents (deep) to destination
 	share (destination, callback) {
+		/* TODO: complete
+		var names = this.contentNames;
+
+		// Make array of content paths
+		var paths = names.map(key => this.contents[key].paths);
+		*/
+	},
+
+	// Share ascii of all contents (deep)
+	shareascii (destination, callback) {
+		/* TODO: complete
 		var names = this.contentNames;
 
 		// Make folder at destination
@@ -120,7 +97,45 @@ var folder = Object.assign(Object.create(file), {
 
 		// Call callback iff all operations succeed
 		tools.waterfall(functs, names, callback);
+		*/
 	},
+
+	// Misc. functions
+	// Add a file
+	// TODO: Verify if works
+	addFile (fileObject) {
+		// TODO: verify that the fileObject belongs in this folder
+		var f = fileFactory(fileObject);
+		this.contents[f.name] = f;
+		f.parentFolder = this;
+		return f;
+	},
+
+	// Add a folder, defined after folderFactory() to use it without breaking
+	// strict convention
+	addFolder (name) {
+		// Copy this folder and erase its state to 'create' a new folder
+		// TODO: This seems like an imperfect way to add a new Folder. Can't
+		// use folderFactory function down below because using the folder
+		// factory again seems to return the same folder. Example:
+		//   rootFolder.addFolder('foo') returns a rootFolder with a path of
+		//   'foo' but all the same contents, resulting in circular pointers
+		//   Thus rootFolder.contents === rootFolder.contents.foo.contents
+		var f = Object.create(this);
+		f.path = this.path !== '' ? `${this.path}/${name}` : name;
+		f.contents = {};
+	
+		// Link new folder to this one and vice versa
+		f.parentFolder = this;
+		this.contents[name] = f;
+		return f;
+	},
+
+	// Return if it's an empty folder
+	isEmpty () {
+		return this.contentsNames.length === 0;
+	},
+
 });
 
 // TODO: How to place a getter in the object definition without it being

--- a/plugins/Files/js/folder.js
+++ b/plugins/Files/js/folder.js
@@ -146,6 +146,58 @@ var folder = Object.assign(Object.create(fileClass), {
 		return this.fileNames.length === 0;
 	},
 
+	// Return if a file belongs in this folder
+	contains (f) {
+		var folderNames;
+		// File passed in is a file object
+		if (typeof f === 'object') {
+			folderNames = f.folderNames;
+		} else if (typeof f === 'string') {
+			// File passed in is a file path
+			folderNames = f.split('/');
+			folderNames.pop();
+		}
+
+		// Verify
+		var index = folderNames.indexOf(this.name);
+		var thisFoldersNames = this.folderNames;
+
+		// Root folder contains all
+		if (this.path === '') {
+			return true;
+		} else if (index === -1) {
+			// This folder's name isn't in the file path
+			return false;
+		} else if (folderNames.length < thisFoldersNames.length) {
+			return false;
+		} else {
+			// Test if all of this folder's names are included in the passed in
+			// file's path
+			return thisFoldersNames.every(function(fName, i) {
+    			return fName === folderNames[i]; 
+			});		
+		}
+	},
+
+	// Return the name a file would show up as in this folder. If the file
+	// doesn't belong in this folder, return -1
+	innerNameOf (f) {
+		if (!this.contains(f)) {
+			return -1;
+		}
+
+		var pathArray;
+		// File passed in is a file object
+		if (typeof f === 'object') {
+			pathArray = f.pathArray;
+		} else if (typeof f === 'string') {
+			// File passed in is a file path
+			pathArray = f.split('/');
+		}
+
+		var index = pathArray.indexOf(this.name);
+		return pathArray[index + 1];
+	}
 });
 
 // TODO: How to place a getter in the object definition without it being

--- a/plugins/Files/js/folderElement.js
+++ b/plugins/Files/js/folderElement.js
@@ -24,6 +24,7 @@ function makeFolderElement(f, navigateTo) {
 	
 	// Share button, when clicked, downloads .sia files to specified location
 	// with the same structure as in the browser
+	/* TODO: move to browser for aggregate action
 	el.find('.share').click(function() {
 		var destination = tools.dialog('save', {
 			title:       `Share ${f.name}'s .sia files'`,
@@ -35,6 +36,7 @@ function makeFolderElement(f, navigateTo) {
 			tools.notify(`Put ${f.name}'s .sia files at ${destination}`, 'download');
 		});
 	});
+	*/
 
 	// Navigate to the folder if the element, not its buttons, is clicked
 	el.dblclick(function(e) {

--- a/plugins/Files/js/folderElement.js
+++ b/plugins/Files/js/folderElement.js
@@ -16,7 +16,7 @@ function makeFolderElement(f, navigateTo) {
 	var el = fileElement(f);
 	el.addClass('folder');
 
-	// Set size as empty if there are no contents
+	// Set size as empty if there are no files
 	if (f.isEmpty()) {
 		el.find('.size').text('empty');
 		el.find('.detail').text('--');

--- a/plugins/Files/js/folderElement.js
+++ b/plugins/Files/js/folderElement.js
@@ -21,7 +21,7 @@ function makeFolderElement(f, navigateTo) {
 		el.find('.size').text('empty');
 		el.find('.detail').text('--');
 	} else {
-		el.find('.detail').text(f.count + ' files');
+		el.find('.detail').text(f.count + ' items');
 	}
 	
 	// Share button, when clicked, downloads .sia files to specified location
@@ -41,6 +41,7 @@ function makeFolderElement(f, navigateTo) {
 	*/
 
 	// Navigate to the folder if the element, not its buttons, is clicked
+	el.off('dblclick');
 	el.dblclick(function(e) {
 		if (!$(e.target).is('.button, .fa')) {
 			navigateTo(f);

--- a/plugins/Files/js/folderElement.js
+++ b/plugins/Files/js/folderElement.js
@@ -19,8 +19,10 @@ function makeFolderElement(f, navigateTo) {
 	// Set size as empty if there are no contents
 	if (f.isEmpty()) {
 		el.find('.size').text('empty');
+		el.find('.detail').text('--');
+	} else {
+		el.find('.detail').text(f.count + ' files');
 	}
-	el.find('.time').text('--');
 	
 	// Share button, when clicked, downloads .sia files to specified location
 	// with the same structure as in the browser

--- a/plugins/Files/js/folderElement.js
+++ b/plugins/Files/js/folderElement.js
@@ -34,22 +34,6 @@ function makeFolderElement(f, navigateTo) {
 	// Populate its fields and graphics
 	updateFolderElement(f, el);
 	
-	// Share button, when clicked, downloads .sia files to specified location
-	// with the same structure as in the browser
-	/* TODO: move to browser for aggregate action
-	el.find('.share').click(function() {
-		var destination = tools.dialog('save', {
-			title:       `Share ${f.name}'s .sia files'`,
-			defaultPath: f.name,
-		});
-
-		// Download siafiles to location
-		f.share(destination, function() {
-			tools.notify(`Put ${f.name}'s .sia files at ${destination}`, 'download');
-		});
-	});
-	*/
-
 	// Navigate to the folder if the element, not its buttons, is clicked
 	el.off('dblclick');
 	el.dblclick(function(e) {

--- a/plugins/Files/js/folderElement.js
+++ b/plugins/Files/js/folderElement.js
@@ -11,10 +11,9 @@ const BigNumber = require('bignumber.js');
 const tools = require('./uiTools');
 const fileElement = require('./fileElement');
 
-// Make folder element with jquery
-function makeFolderElement(f, navigateTo) {
-	var el = fileElement(f);
-	el.addClass('folder');
+// Update file element with jquery
+function updateFolderElement(f, el) {
+	el = el || $('#' + f.hashedPath);
 
 	// Set size as empty if there are no files
 	if (f.isEmpty()) {
@@ -23,6 +22,17 @@ function makeFolderElement(f, navigateTo) {
 	} else {
 		el.find('.detail').text(f.count + ' items');
 	}
+
+	return el;
+}
+
+// Make folder element with jquery
+function makeFolderElement(f, navigateTo) {
+	var el = fileElement(f);
+	el.addClass('folder');
+
+	// Populate its fields and graphics
+	updateFolderElement(f, el);
 	
 	// Share button, when clicked, downloads .sia files to specified location
 	// with the same structure as in the browser
@@ -52,4 +62,11 @@ function makeFolderElement(f, navigateTo) {
 	return el;
 }
 
-module.exports = makeFolderElement;
+module.exports = function(f, funct) {
+	// Determine to update or add a folder element based on if it exists already
+	if (!$('#' + f.hashedPath).length) {
+		return makeFolderElement(f, funct);
+	} else {
+		return updateFolderElement(f);
+	}
+};

--- a/plugins/Files/js/global.js
+++ b/plugins/Files/js/global.js
@@ -155,9 +155,9 @@ $(document).on('click', function(event) {
 	if (!fileClicked) {
 		browser.deselectAll();
 	}
-	var fileNameClicked = el.closest('.name.button').length;
+	var fileNameClicked = el.closest('.name').length;
 	if (!fileNameClicked) {
-		let edited = $('.name.button[contentEditable=true]');
+		let edited = $('.name[contentEditable=true]');
 		edited.text(edited.attr('id')).attr('contentEditable', false);
 	}
 });

--- a/plugins/Files/js/global.js
+++ b/plugins/Files/js/global.js
@@ -44,9 +44,13 @@ browser.update();
 $('#home-folder').click(browser.navigateTo);
 
 // File list search
-$('#search-bar').keypress(function() {
+$('#search-bar').keyup(function() {
 	tools.tooltip('Searching...', this);
-	browser.filter(this.value);
+	if (this.value) {
+		browser.filter(this.value);
+	} else {
+		browser.update();
+	}
 });
 
 // Dropdown below the new button

--- a/plugins/Files/js/global.js
+++ b/plugins/Files/js/global.js
@@ -111,32 +111,6 @@ $('#paste-ascii input').keypress(function(e) {
 	}
 });
 
-// Clicking within the file-list affects what elements are selected
-$('#file-browser').click(function(e) {
-	e.preventDefault();
-	var el = $(e.target);
-	var file = el.closest('.file:not(.label)');
-
-	// Don't react to button clicks
-	var buttonClicked = el.closest('.button').length;
-	if (buttonClicked) {
-		return;
-	}
-
-	// Clicking affects selected items
-	if (e.shiftKey) {
-		browser.selectTo(file);
-	} else if (e.ctrlKey) {
-		browser.toggle(file);
-	} else {
-		browser.deselectAll();
-		var fileClicked = file.length;
-		if (fileClicked) {
-			browser.select(file);
-		}
-	}
-});
-
 // Clicking controls buttons affects selected elements
 // TODO: Needs testing
 $('.controls .delete').click(browser.deleteSelected);
@@ -150,19 +124,38 @@ $('.controls .button').fadeOut();
 // and stops file name editing
 $(document).on('click', function(event) {
 	var el = $(event.target);
+	// Don't react to button clicks
+	var buttonClicked = el.closest('.button').length;
+	if (buttonClicked) {
+		return;
+	}
 	var dropdownClicked = el.closest('.dropdown').length;
 	var lastDirectoryClicked = el.closest('#cwd').length && el.closest('.directory').is(':last-child');
 	if (!dropdownClicked && !lastDirectoryClicked) {
 		$('.dropdown').hide('fast');
 	}
-	var fileClicked = el.closest('.file').length;
+	// Clicking affects what elements are selected
+	var file = el.closest('.file:not(.label)');
+	var fileClicked = file.length;
 	if (!fileClicked) {
 		browser.deselectAll();
+	} else {
+		// Clicking affects selected items
+		if (event.shiftKey) {
+			browser.selectTo(file);
+		} else if (event.ctrlKey) {
+			browser.toggle(file);
+		} else {
+			if (fileClicked) {
+				browser.select(file);
+			}
+			browser.deselectAll(file);
+		}
 	}
 	var fileNameClicked = el.closest('.name').length;
 	var fileNameButtonClicked = el.prev('.name').length;
 	if (!fileNameClicked && !fileNameButtonClicked) {
 		let edited = $('.name[contentEditable=true]');
-		edited.text(edited.attr('id')).attr('contentEditable', false);
+		edited.text(edited.find('.name').text()).attr('contentEditable', false);
 	}
 });

--- a/plugins/Files/js/global.js
+++ b/plugins/Files/js/global.js
@@ -115,7 +115,7 @@ $('#paste-ascii input').keypress(function(e) {
 $('#file-browser').click(function(e) {
 	e.preventDefault();
 	var el = $(e.target);
-	var file = el.closest('.file');
+	var file = el.closest('.file:not(.label)');
 
 	// Don't react to button clicks
 	var buttonClicked = el.closest('.button').length;
@@ -130,7 +130,10 @@ $('#file-browser').click(function(e) {
 		browser.toggle(file);
 	} else {
 		browser.deselectAll();
-		browser.select(file);
+		var fileClicked = file.length;
+		if (fileClicked) {
+			browser.select(file);
+		}
 	}
 });
 
@@ -147,8 +150,9 @@ $('.controls .download').click(browser.downloadSelected);
 $(document).on('click', function(event) {
 	var el = $(event.target);
 	var dropdownClicked = el.closest('.dropdown').length;
-	var lastDirectoryClicked = el.closest('#cwd').length && el.is(':last-child');
+	var lastDirectoryClicked = el.closest('#cwd').length && el.closest('.directory').is(':last-child');
 	if (!dropdownClicked && !lastDirectoryClicked) {
+		console.log('yo')
 		$('.dropdown').hide('fast');
 	}
 	var fileClicked = el.closest('.file').length;
@@ -156,7 +160,8 @@ $(document).on('click', function(event) {
 		browser.deselectAll();
 	}
 	var fileNameClicked = el.closest('.name').length;
-	if (!fileNameClicked) {
+	var fileNameButtonClicked = el.prev('.name').length;
+	if (!fileNameClicked && !fileNameButtonClicked) {
 		let edited = $('.name[contentEditable=true]');
 		edited.text(edited.attr('id')).attr('contentEditable', false);
 	}

--- a/plugins/Files/js/global.js
+++ b/plugins/Files/js/global.js
@@ -35,6 +35,8 @@ siad.apiCall = function(callObj, callback) {
 		}
 	});
 };
+// Ensure browser updates once initially
+browser.update();
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Buttons ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Home folder button

--- a/plugins/Files/js/global.js
+++ b/plugins/Files/js/global.js
@@ -136,7 +136,9 @@ $('#file-browser').click(function(e) {
 
 
 // Clicking controls buttons affects selected elements
+// TODO: Needs testing
 $('.controls .delete').click(browser.deleteSelected);
+// TODO: Need to make browser.shareSelected
 $('.controls .share').click(browser.shareSelected);
 $('.controls .download').click(browser.downloadSelected);
 

--- a/plugins/Files/js/global.js
+++ b/plugins/Files/js/global.js
@@ -137,13 +137,14 @@ $('#file-browser').click(function(e) {
 	}
 });
 
-
 // Clicking controls buttons affects selected elements
 // TODO: Needs testing
 $('.controls .delete').click(browser.deleteSelected);
 // TODO: Need to make browser.shareSelected
 $('.controls .share').click(browser.shareSelected);
 $('.controls .download').click(browser.downloadSelected);
+// Hide buttons to start, they're shown when files are selected
+$('.controls .button').fadeOut();
 
 // Clicking the general document closes popups, deselects files,
 // and stops file name editing
@@ -152,7 +153,6 @@ $(document).on('click', function(event) {
 	var dropdownClicked = el.closest('.dropdown').length;
 	var lastDirectoryClicked = el.closest('#cwd').length && el.closest('.directory').is(':last-child');
 	if (!dropdownClicked && !lastDirectoryClicked) {
-		console.log('yo')
 		$('.dropdown').hide('fast');
 	}
 	var fileClicked = el.closest('.file').length;

--- a/plugins/Files/js/global.js
+++ b/plugins/Files/js/global.js
@@ -35,6 +35,7 @@ siad.apiCall = function(callObj, callback) {
 		}
 	});
 };
+
 // Ensure browser updates once initially
 browser.update();
 
@@ -126,15 +127,25 @@ $('.controls .button').fadeOut();
 // and stops file name editing
 $(document).on('click', function(event) {
 	var el = $(event.target);
-	// Don't react to button clicks
-	var buttonClicked = el.closest('.button').length;
-	if (buttonClicked) {
-		return;
-	}
+	// Clicking minimizes the dropdown
 	var dropdownClicked = el.closest('.dropdown').length;
 	var lastDirectoryClicked = el.closest('#cwd').length && el.closest('.directory').is(':last-child');
 	if (!dropdownClicked && !lastDirectoryClicked) {
 		$('.dropdown').hide('fast');
+	}
+	// Clicking cancels file name editing
+	var fileNameClicked = el.closest('.name').length;
+	var fileNameButtonClicked = el.prev('.name').length;
+	if (!fileNameClicked && !fileNameButtonClicked) {
+		let edited = $('.name[contentEditable=true]');
+		let name = edited.attr('id');
+		edited.text(name).attr('contentEditable', false);
+	}
+	// Don't react to button clicks past this
+	var buttonClicked = el.closest('.button').length;
+	if (buttonClicked) {
+		browser.deselectAll();
+		return;
 	}
 	// Clicking affects what elements are selected
 	var file = el.closest('.file:not(.label)');
@@ -153,11 +164,5 @@ $(document).on('click', function(event) {
 			}
 			browser.deselectAll(file);
 		}
-	}
-	var fileNameClicked = el.closest('.name').length;
-	var fileNameButtonClicked = el.prev('.name').length;
-	if (!fileNameClicked && !fileNameButtonClicked) {
-		let edited = $('.name[contentEditable=true]');
-		edited.text(edited.find('.name').text()).attr('contentEditable', false);
 	}
 });

--- a/plugins/Files/js/lifecycle.js
+++ b/plugins/Files/js/lifecycle.js
@@ -16,14 +16,14 @@ const browser = require('./browser');
 // Keeps track of if the view is shown
 var updating;
 // 'all' or 'active'
-var hostsType = 'all';
+var hostsType = 'active';
 // Hastings per Siacoin (1e24) / B per GB (1e9) / Blocks per 30-day month (4320)
 const MONTHLY_DATA_COST = new BigNumber('1e+24').div('1e+9').div('4320');
 
 // Update capsule values with renter status
 function updateStatus(result) {
 	var priceDisplay;
-    var hostsDisplay = hostsType === 'all' ? ' Hosts' : ' Active Hosts';
+    var hostsDisplay = hostsType === 'active' ? ' Active Hosts' : ' Hosts';
 
 	// Determine capsule display values
 	if (result.hosts) {
@@ -60,7 +60,7 @@ function update() {
 // Clicking the host pod toggles it between all hosts and active hosts
 $('#host-count.pod').click(function() {
 	$('#host-count.pod .fa').toggleClass('fa-globe fa-users');
-	hostsType = hostsType === 'all' ? 'active' : 'all';
+	hostsType = hostsType === 'active' ? 'all' : 'active';
 	update();
 });
 

--- a/plugins/Files/js/loader.js
+++ b/plugins/Files/js/loader.js
@@ -11,11 +11,11 @@ const path = require('path');
 const tools = require('./uiTools');
 const siad = require('sia.js');
 
-// Uploads a file from the given filePath to the given virtualPath.
-function uploadFile(filePath, virtualPath, callback) {
+// Uploads a file from the given source to the given virtualPath.
+function uploadFile(source, virtualPath, callback) {
 	// Determine the nickname
-	var name = path.basename(filePath);
-	var nickname = `${virtualPath.path}/${name}`;
+	var name = path.basename(source);
+	var nickname = `${virtualPath}/${name}`;
 
 	// Upload the file
 	tools.notify(`Uploading ${name}!`, 'upload');
@@ -23,7 +23,8 @@ function uploadFile(filePath, virtualPath, callback) {
 		url: '/renter/upload/' + nickname,
 		method: 'POST',
 		qs: {
-			source: filePath,
+			source: source,
+			renew: true,
 		},
 	}, callback);
 }
@@ -50,13 +51,13 @@ function uploadFolder(dirPath, virtualPath, callback) {
 }
 
 // Loads a .sia file into the library
-function loadDotSia(filePath, callback) {
-	var name = path.basename(filePath, '.sia');
+function loadDotSia(source, callback) {
+	var name = path.basename(source, '.sia');
 	siad.apiCall({
 		url: '/renter/load',
 		method: 'POST',
 		qs: {
-			filename: filePath,
+			source: source,
 		}
 	}, function(result) {
 		if (callback) {
@@ -73,7 +74,7 @@ function loadAscii(ascii, callback) {
 		url: '/renter/loadascii',
 		method: 'POST',
 		qs: {
-			file: ascii,
+			asciisia: ascii,
 		}
 	}, function(result) {
 		if (callback) {

--- a/plugins/Files/js/loader.js
+++ b/plugins/Files/js/loader.js
@@ -95,18 +95,35 @@ function loadAscii(ascii, callback) {
 		qs: {
 			asciisia: ascii,
 		}
-	}, function(result) {
-		if (callback) {
-			callback(result);
+	}, callback);
+}
+
+// Place one .sia file to destination for potentially many file paths
+function shareDotSia(paths, destination, callback) {
+	siad.apiCall({
+		url: '/renter/share',
+		qs: {
+			siapaths: paths.join(','),
+			destination: destination,
 		}
-		// TODO: Read result.FilesAdded and interpret for notification
-		tools.notify('Added ascii file(s)!', 'asciifile');
-	});
+	}, callback);
+}
+
+// Share one .sia ascii for potentially many file paths
+function shareAscii(paths, callback) {
+	siad.apiCall({
+		url: '/renter/shareascii',
+		qs: {
+			siapaths: paths.join(','),
+		}
+	}, callback);
 }
 
 module.exports = {
 	uploadFile: uploadFile,
 	uploadFolder: uploadFolder,
-	loadAscii: loadAscii,
 	loadDotSia: loadDotSia,
+	loadAscii: loadAscii,
+	shareDotSia: shareDotSia,
+	shareAscii: shareAscii,
 };

--- a/plugins/Files/js/loader.js
+++ b/plugins/Files/js/loader.js
@@ -11,6 +11,24 @@ const path = require('path');
 const tools = require('./uiTools');
 const siad = require('sia.js');
 
+// Whether to upload files with autorenew feature or some block duration
+// Default behavior is to renew automatically
+// TODO: Settings page
+var renew = true;
+var duration = null;
+
+// Get files plugin settings for uploading
+var settings = tools.config('files');
+if (!settings) {
+	tools.config('files', {
+		renew: renew,
+		duration: duration,
+	});
+} else {
+	renew = settings.renew;
+	duration = settings.duration;
+}
+
 // Uploads a file from the given source to the given virtualPath.
 function uploadFile(source, virtualPath, callback) {
 	// Determine the nickname
@@ -24,7 +42,8 @@ function uploadFile(source, virtualPath, callback) {
 		method: 'POST',
 		qs: {
 			source: source,
-			renew: true,
+			duration: duration,
+			renew: renew,
 		},
 	}, callback);
 }

--- a/plugins/Files/js/loader.js
+++ b/plugins/Files/js/loader.js
@@ -31,14 +31,14 @@ if (!settings) {
 
 // Uploads a file from the given source to the given virtualPath.
 function uploadFile(source, virtualPath, callback) {
-	// Determine the nickname
+	// Determine the siapath
 	var name = path.basename(source);
-	var nickname = `${virtualPath}/${name}`;
+	var siapath = `${virtualPath}/${name}`;
 
 	// Upload the file
 	tools.notify(`Uploading ${name}!`, 'upload');
 	siad.apiCall({
-		url: '/renter/upload/' + nickname,
+		url: '/renter/upload/' + siapath,
 		method: 'POST',
 		qs: {
 			source: source,
@@ -60,7 +60,7 @@ function uploadFolder(dirPath, virtualPath, callback) {
 			return;
 		}
 
-		// Process files into sources and nicknames
+		// Process files into sources and siapaths
 		var filePaths = files.map(file => path.resolve(dirPath, file));
 		// Process the appropriate function per file
 		var functs = filePaths.map(filePath =>

--- a/plugins/Files/js/uiTools.js
+++ b/plugins/Files/js/uiTools.js
@@ -103,9 +103,9 @@ module.exports = {
 
 		// Call funct per array item
 		array.forEach(function(item) {
-			var specificParams = params.slice(0);
-			specificParams.unshift(item);
-			funct.apply(null, specificParams);
+			var singleParam = params.slice(0);
+			singleParam.unshift(item);
+			funct.apply(null, singleParam);
 		});
 	},
 
@@ -117,7 +117,7 @@ module.exports = {
 
 		// Any amount of optional parameters
 		var params = [];
-		for (let i = 2; i < arguments.length - 1; i++) {
+		for (let i = 1; i < arguments.length - 1; i++) {
 			let arg = arguments[i];
 			params.push(arg);
 		}
@@ -146,8 +146,8 @@ module.exports = {
 
     	// Call per function with params (Array or single param allowed)
 		functs.forEach(function(funct, index) {
-			var specificParams = params.map(param => Array.isArray(param) ? param[index] : param);
-			funct.apply(null, specificParams);
+			var singleParams = params.map(param => Array.isArray(param) ? param[index] : param);
+			funct.apply(null, singleParams);
 		});
 	},
 	

--- a/plugins/Files/js/uiTools.js
+++ b/plugins/Files/js/uiTools.js
@@ -34,8 +34,11 @@ module.exports = {
 	
 	// Config shortcut
 	config (key, value) {
-		value = value || undefined;
-		return ipcRenderer.sendSync('config', key);
+		if (value === undefined) {
+			return ipcRenderer.sendSync('config', key);
+		} else {
+			return ipcRenderer.sendSync('config', key, value);
+		}
 	},
 	
 	// Dialog shortcut

--- a/plugins/Files/js/uiTools.js
+++ b/plugins/Files/js/uiTools.js
@@ -45,10 +45,14 @@ module.exports = {
 	dialog (type, options) {
 		return ipcRenderer.sendSync('dialog', type, options);
 	},
-	
-	// Checks whether a path starts with or contains a hidden file or a folder.
-	isUnixHiddenPath (path) {
-		return (/(^|\/)\.[^\/\.]/g).test(path);
+
+	// Logs an error to output for non-string arguments
+	notType (str, type) {
+		if (typeof str !== type) {
+			console.error('Improper argument!', str);
+			return true;
+		}
+		return false;
 	},
 	
 	// Format to data size representation with 3 or less digits

--- a/plugins/Hosting/index.html
+++ b/plugins/Hosting/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<title>Hosting</title>
 		<!-- CSS -->
 		<link rel='stylesheet' href='../../css/roboto-condensed-min.css'>
 		<link rel='stylesheet' href='../../css/font-awesome.min.css'>

--- a/plugins/Overview/index.html
+++ b/plugins/Overview/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<title>Overview</title>
 		<!-- CSS -->
 		<link rel="stylesheet" href="../../css/roboto-condensed-min.css">
 		<link rel="stylesheet" href="../../css/font-awesome.min.css">

--- a/plugins/Wallet/index.html
+++ b/plugins/Wallet/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<title>Wallet</title>
 		<!-- CSS -->
 		<link rel='stylesheet' href='../../css/roboto-condensed-min.css'>
 		<link rel='stylesheet' href='../../css/font-awesome.min.css'>

--- a/plugins/Wallet/js/addresses.js
+++ b/plugins/Wallet/js/addresses.js
@@ -94,8 +94,8 @@ $('#view-all-addresses').click(function() {
 function filterAdresses(searchstr) {
 	// Filter
 	searchedAddresses = addresses.map(address => ({address: address}));
-	searchedAddresses = searchedAddresses.filter(function(addressObject) {
-		return (addressObject.address.indexOf(searchstr) > -1);
+	searchedAddresses = addresses.filter(function(addressObject) {
+		return (addressObject.address.includes(searchstr));
 	});
 }
 

--- a/plugins/Wallet/js/addresses.js
+++ b/plugins/Wallet/js/addresses.js
@@ -45,7 +45,7 @@ function makeAddress(address, number) {
 
 // Fill address page with search results or addresses
 function updateAddressPage() {
-	// TODO: Merge this into Transaction's filter criteria and make an overall
+	// TODO: Merge itemsPerPage into Transaction's filter criteria and make an overall
 	// settings object, perhaps just as a member of the `wallet` object
 	var itemsPerPage = 25;
 	$('#address-list').empty();

--- a/plugins/Wallet/js/buttons.js
+++ b/plugins/Wallet/js/buttons.js
@@ -3,9 +3,9 @@
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Capsule ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Get and use password from the UI's config.json
 function getPassword() {
-	var pw = IPCRenderer.sendSync('config', 'walletPassword');
-	if (pw) {
-		unlock(pw);
+	var settings = IPCRenderer.sendSync('config', 'wallet');
+	if (settings && settings.password !== undefined && settings.password !== null) {
+		unlock(settings.password);
 	} else {
 		$('#request-password').show();
 		$('#password-field').focus();
@@ -29,7 +29,9 @@ $('#lock-pod').click(function() {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Popups ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Save password to the UI's config.json
 function savePassword(pw) {
-	IPCRenderer.sendSync('config', 'walletPassword', pw);
+	var settings = IPCRenderer.sendSync('config', 'wallet') || {};
+	settings.password = pw;
+	IPCRenderer.sendSync('config', 'wallet', settings);
 }
 
 // On popup upon entering an encrypted, locked wallet, enter password

--- a/plugins/Wallet/js/locking.js
+++ b/plugins/Wallet/js/locking.js
@@ -105,7 +105,13 @@ function encrypt() {
 		popup.show();
 	
 		// Clear old password in config if there is one
-		IPCRenderer.sendSync('config', 'walletPassword', null);
+		var settings = IPCRenderer.sendSync('config', 'wallet');
+		if (settings) {
+			settings.password = null;
+		} else {
+			settings = {password: null};
+		}
+		IPCRenderer.sendSync('config', 'wallet', settings);
 	
 		// Show password in the popup
 		$('#generated-password').text(result.primaryseed);

--- a/plugins/Wallet/js/transactions.js
+++ b/plugins/Wallet/js/transactions.js
@@ -35,7 +35,7 @@ function checkCriteria(txn) {
 	       (criteria.startTime === null || txn.confirmationtimestamp >= criteria.startTime) &&
 	       (criteria.maxValue  === null || txn.value                 <= criteria.maxValue)  &&
 	       (criteria.minValue  === null || txn.value                 >= criteria.minValue)  &&
-	       (criteria.currency  === null || criteria.currency.indexOf(txn.currency) !== -1)  &&
+	       (criteria.currency  === null || criteria.currency.includes(txn.currency))        &&
 	       (criteria.inputs    === true || txn.value                 >= 0)                  &&
 	       (criteria.outputs   === true || txn.value                 <= 0);
 }


### PR DESCRIPTION
- Adapted to new API
- Fixed various bugs (Still addressing many concerns of #175 though)
- Share and shareascii for folders
- Also fixed some deprecated api usage (file.nickname -> file.siapath)
  - Reflect new `renew` attribute in files and file elements
- tools.notType(), function to log improper arguments
  - Check param in each file/folder function
- Removed file.size and file.count getters, trying not to cater file class to folder class. Folder should strictly inherit from file
- Name fields do not take up more space than needed

Note: Many buttons still not working. Much `TODO:`
