### PR TITLE
More Files plugin fixes

### DIFF
--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -400,7 +400,10 @@ var browser = {
 			tools.tooltip('No selected files', $('.controls .download').get(0));
 			return;
 		} else if (itemCount === 1) {
-			// Save file/folder into specific place
+			if (files[0].type === 'folder') {
+				tools.notify('No support for downloading folders (yet)', 'error');
+				return;
+			}
 			label = files[0].name;
 			destination = tools.dialog('save', {
 				title: 'Download ' + label,
@@ -414,15 +417,14 @@ var browser = {
 				tools.notify(`Downloaded ${label} to ${destination}`, 'success');
 			});
 		} else {
-			let totalCount = files.reduce(function(a, b) {
-				if (b.type === 'folder') {
-					return a + b.count;
-				} else {
-					return ++a;
+			for (let file of files) {
+				if (file.type === 'folder') {
+					tools.notify('No support for downloading folders (yet)', 'error');
+					return;
 				}
-			}, 0);
-			// Save files/folders into directory
-			label = totalCount + ' files';
+			}
+			// Save files into directory
+			label = itemCount + ' files';
 			destination = tools.dialog('open', {
 				title: 'Download ' + label,
 				properties: ['openDirectory', 'createDirectory'],
@@ -432,11 +434,11 @@ var browser = {
 			}
 			// Download each of the files
 			tools.notify(`Downloading ${label} to ${destination}`, 'download');
-				let functs = files.map(file => file.download.bind(file));
-				let destinations = files.map(file => path.join(destination, file.name));
-				tools.waterfall(functs, destinations, function() {
-					tools.notify(`Downloaded ${label} to ${destination}`, 'success');
-				});
+			let functs = files.map(file => file.download.bind(file));
+			let destinations = files.map(file => path.join(destination, file.name));
+			tools.waterfall(functs, destinations, function() {
+				tools.notify(`Downloaded ${label} to ${destination}`, 'success');
+			});
 		}
 	},
 

--- a/plugins/Files/js/browser.js
+++ b/plugins/Files/js/browser.js
@@ -406,6 +406,13 @@ var browser = {
 				title: 'Download ' + label,
 				defaultPath: label,
 			});
+			if (!destination) {
+				return;
+			}
+			// Download the file
+			files[0].download(destination, function() {
+				tools.notify(`Downloaded ${label} to ${destination}`, 'success');
+			});
 		} else {
 			let totalCount = files.reduce(function(a, b) {
 				if (b.type === 'folder') {
@@ -420,20 +427,17 @@ var browser = {
 				title: 'Download ' + label,
 				properties: ['openDirectory', 'createDirectory'],
 			});
+			if (!destination) {
+				return;
+			}
+			// Download each of the files
+			tools.notify(`Downloading ${label} to ${destination}`, 'download');
+				let functs = files.map(file => file.download.bind(file));
+				let destinations = files.map(file => path.join(destination, file.name));
+				tools.waterfall(functs, destinations, function() {
+					tools.notify(`Downloaded ${label} to ${destination}`, 'success');
+				});
 		}
-
-		// Ensure destination exists
-		if (!destination) {
-			return;
-		}
-
-		// Setup async calls to each file to download them
-		tools.notify(`Downloading ${label} to ${destination}`, 'download');
-			let functs = files.map(file => file.download.bind(file));
-			let destinations = files.map(file => `${destination}/${file.name}`);
-			tools.waterfall(functs, destinations, function() {
-				tools.notify(`Downloaded ${label} to ${destination}`, 'success');
-			});
 	},
 
 	// Filter file list by search string

--- a/plugins/Files/js/folderElement.js
+++ b/plugins/Files/js/folderElement.js
@@ -30,8 +30,6 @@ function updateFolderElement(f, el) {
 function makeFolderElement(f, navigateTo) {
 	var el = fileElement(f);
 	el.addClass('folder');
-	// add a / to distinguish folders
-	el.find('.name').text(f.name + '/');
 
 	// Populate its fields and graphics
 	updateFolderElement(f, el);

--- a/plugins/Files/js/global.js
+++ b/plugins/Files/js/global.js
@@ -55,7 +55,7 @@ $('#search-bar').keyup(function() {
 
 // Dropdown below the new button
 $('.dropdown .button').click(function() {
-	var userInput;
+	var userInput = true; // ok by default; will be set to undefined if user input fails
 	var option = this.textContent.trim();
 
 	// Dialog window options common to any button case that uses it
@@ -85,7 +85,7 @@ $('.dropdown .button').click(function() {
 			$('.dropdown li').hide('fast');
 			$('#paste-ascii').show('fast');
 			$('#paste-ascii input').focus();
-			return; // Don't close dropdown
+			break;
 		case 'Load ASCII File':
 			userInput = $('#paste-ascii input').val();
 			$('.dropdown li').show('fast');
@@ -94,20 +94,17 @@ $('.dropdown .button').click(function() {
 			break;
 		default:
 			console.error('Unknown button!', this);
-			return; // Don't close dropdown
-	}
-
-	// Detect flawed userInput from actions that require it, hide if fine
-	if (!userInput && option !== 'Make Folder') {
-		tools.tooltip('Invalid action!', this);
-		return; // Don't close dropdown
+			break;
 	}
 
 	// Close dropdown
 	$('.dropdown').hide('fast');
 
-	// Call the function that corresponds to the selected option
-	browser[option](userInput, browser.update);
+	// If the input was valid, call the function that corresponds to the
+	// selected option
+	if (userInput) {
+		browser[option](userInput, browser.update);
+	}
 });
 
 // Show add-ascii-file button when input box has content

--- a/plugins/Files/js/loader.js
+++ b/plugins/Files/js/loader.js
@@ -72,7 +72,7 @@ function uploadFolder(dirPath, siapath, callback) {
 		// Process the appropriate function per file
 		var functs = filePaths.map(filePath =>
 			fs.statSync(filePath).isFile() ? uploadFile : uploadFolder);
-		tools.waterfall(functs, siapath, callback);
+		tools.waterfall(functs, filePaths, siapath, callback);
 	});
 }
 


### PR DESCRIPTION
Single-file downloads were not being downloaded to the correct location, since the download destination was constructed as: `${destination}/${file.name}`. For multiple files this makes sense, but for a single file it
constructs the wrong path; we just want `${destination}`.

Also replaced one use of `/` with `path.join`, to create proper paths on Windows. There may be some other uses of `/` that cause problems, but it seems unlikely; node apparently interprets `/` as the path separator regardless of operating system.
