### PR TITLE
Remove screen header

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -40,22 +40,19 @@ html,body {
 }
 .body {
 	position: relative;
-
-	height: -webkit-calc(100% - 80px);
-	-webkit-box-sizing:border-box;
+	height: 100%;
+	-webkit-box-sizing: border-box;
 }
 
 /* UI Header */
 .header {
-	height: 80px;
+	height: 60px;
 	width: 100%;
-
-	background-color: #313133;
-	background: linear-gradient(to left, #313133 15%, #0b0e16 85%);
+	background-color: #0b0e16;
 }
 .logo {
 	padding-left: 20px;
-	padding-top: 14px;
+	padding-top: 7px;
 	pointer-events: none;
 }
 .logo-container:hover {
@@ -63,30 +60,19 @@ html,body {
 }
 
 /* Header Buttons */
-.header-button {
-	float: right;
+#update-ui {
 	display: none;
-	padding: 30px;
-	font-size: 16px;
-	color: #AAAAAA;
-}
-.header-button:hover {
-	color: #00CBA0;
-	cursor: pointer;
 }
 
 /* Sidebar */
 #sidebar {
 	position: relative;
-
 	background-color: #D5D3D5;
 	width: 160px;
 	z-index: 1000;
 	height: 100%;
-
 	-webkit-box-sizing:border-box;
-	border-left: 0 solid #F5F5F5;
-	border-right: 1px solid #B5B5B5;
+	border-right: 0px solid #B5B5B5;
 }
 .button {
 	display: flex;

--- a/css/plugin-standard.css
+++ b/css/plugin-standard.css
@@ -61,14 +61,15 @@ select:hover {
 /* Plugin header */
 .header {
 	padding-top: 10px;
-	padding-left: 20px;
-	background-color: #4a4a4a;
+	padding-left: 6px;
 	background: linear-gradient(to top, #5A5A5A 15%, #4A4A4A 85%);
+	background: linear-gradient(to left, #313133, #0b0e16);
 	color: #fff;
 	height: 50px;
 	vertical-align: top;
 }
 .header .title {
+	padding-top: 4px;
 	display: inline-block;
 	font-size: 30px;
 	color: #fff;
@@ -116,6 +117,9 @@ select:hover {
 	position: relative;
 	width: 100%;
 	-webkit-animation: fadein 0.5s;
+}
+.box {
+	border-left: 1px solid #B5B5B5;
 }
 .button {
 	-webkit-user-select: none;

--- a/index.html
+++ b/index.html
@@ -11,27 +11,25 @@
 	</head>
 
 	<body>
-		<!-- Header for UI -->
-		<div class='pure-g header'>
-			<div class='pure-u-1-5 logo-container'>
-				<img src='assets/siaLogo.svg' height='50' class='logo'>
-			</div>
-			<div class='pure-u-4-5 button-container'>
-				<div class='header-button' id='update-ui'>
-					<i class='fa fa-arrow-circle-o-up'></i>
-					Update UI
-				</div>
-				<div class='header-button' id='update-ui'>
-					<i class='fa fa-arrow-circle-o-up'></i>
-					Update Sia
-				</div>
-			</div>
-		</div>
-	
 		<!-- Full body of UI -->
 		<div class='pure-g body'>
 			<!-- Sidebar -->
 			<div class='pure-u-1-5' id='sidebar'>
+				<!-- Header for UI -->
+				<div class='pure-g header'>
+					<div class='pure-u-1-5 logo-container'>
+						<img src='assets/siaLogo.svg' height='44' class='logo'>
+					</div>
+				</div>
+			
+				<div class='pure-u-1-1 button' id='update-ui'>
+					<img class="pure-u icon"><i class='fa fa-arrow-circle-o-up'></i>
+					<div class="pure-u- text">Update UI</div>
+				</div>
+				<div class='pure-u-1-1 button' id='update-ui'>
+					<img class="pure-u icon"><i class='fa fa-arrow-circle-o-up'></i>
+					<div class="pure-u- text">Update Sia</div>
+				</div>
 			</div>
 	
 			<!-- Mainbar -->


### PR DESCRIPTION
This proposal is inspired by @irontiga's PR that removes the screen header and moves the update icons to the sidebar.

Changes:
- Remove screen header
- Move update icons to sidebar (show only when there is an update)

![screenshot from 2016-01-23 23 39 53](https://cloud.githubusercontent.com/assets/1565499/12535141/6e42433a-c22d-11e5-9834-c6e638cf12bf.png)
![screenshot from 2016-01-23 23 39 26](https://cloud.githubusercontent.com/assets/1565499/12535142/6fa2229a-c22d-11e5-80c6-622250b6f05a.png)
