### PR TITLE
Update electron version

### DIFF
--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -12,7 +12,7 @@ var overlay = $('.overlay');
 // from siad for too long
 var crashClock;
 function crash(err) {
-	var crashText = err.toString() || 'Siad has stopped responding :(';
+	var crashText = 'Siad has stopped responding: ' + err;
 	overlay.find('.centered').text(crashText);
 	IPCRenderer.removeAllListeners('siad');
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "chai-as-promised": "^5.1.0",
     "electron-mocha": "^0.7.0",
     "electron-packager": "^5.2.0",
-    "electron-prebuilt": "^0.36.3",
+    "electron-prebuilt": "^0.36.7",
     "ink-docstrap": "^1.0.3",
     "jsdoc": "^3.4.0",
     "jshint": "^2.9.1-rc1",


### PR DESCRIPTION
Should fix the JS error in #207 because of
https://github.com/atom/electron/releases/tag/v0.36.7

Should also fix the crash message being just a "1" or "0" sometimes as also mentioned in #207
