### PR TITLE
UI exit handling from the tray

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -51,7 +51,7 @@
 	"smarttabs"     : false,    // Tolerate mixed tabs and spaces when the latter are used for alignmnent only.
 	"shadow"        : false,    // Allows re-define variables later in code e.g. `var x=1; x=2;`.
 	"sub"           : false,    // Tolerate all forms of subscript notation besides dot notation e.g. `dict['key']` instead of `dict.key`.
-	"supernew"      : false,    // Tolerate `new function () { ... };` and `new Object;`.
+	"supernew"      : false,    // Tolerate `new function() { ... };` and `new Object;`.
 	"validthis"     : false,    // Tolerate strict violations when the code is running in strict mode and you use this in a non-constructor function.
 
 	// == Environments ====================================================

--- a/index.js
+++ b/index.js
@@ -25,25 +25,25 @@ var config = require('./js/mainjs/config.js')(Path.join(__dirname, 'config.json'
 App.on('ready', function() {
 	// Load mainWindow
 	mainWindow = require('./js/mainjs/initWindow.js')(config);
-	// Load tray icon
+	// Load siad
+	require('./js/mainjs/initSiad.js')(config, mainWindow);
+	// Load tray icon and menu
 	var iconPath = Path.join(__dirname, 'assets', 'tray.png');
 	appIcon = new Tray(iconPath);
 	appIcon.setToolTip('Sia - The Collaborative Cloud.');
-	appIcon.setContextMenu(appTray(mainWindow));
+	appIcon.setContextMenu(appTray(mainWindow, App));
 
 	// Add IPCMain listeners
 	require('./js/mainjs/addIPCListeners.js')(config, mainWindow);
 
-	// Upon exiting, dereference the window object so that the GC cleans up.
-	mainWindow.on('close', function() {
-		mainWindow = null;
+	// Catch mainWindow's close event and minimize instead.
+	mainWindow.on('close', function(e) {
+		e.preventDefault();
+		mainWindow.minimize();
 	});
-
-	// Load siad
-	require('./js/mainjs/initSiad.js')(config, mainWindow);
 });
-
-// Quit when UI window closing
+// Quit when the main UI window has been closed.
+// This can only happen when the user has quit the application from the tray.
 App.on('window-all-closed', function() {
 	config.save();
 	App.quit();

--- a/index.js
+++ b/index.js
@@ -36,8 +36,10 @@ App.on('ready', function() {
 
 	// Catch mainWindow's close event and minimize instead.
 	mainWindow.on('close', function(e) {
-		e.preventDefault();
-		mainWindow.minimize();
+		if (!mainWindow.wantsQuit) {
+			e.preventDefault();
+			mainWindow.minimize();
+		}
 	});
 	// Load siad
 	var Siad = require('./js/mainjs/initSiad.js')(config, mainWindow);
@@ -56,4 +58,3 @@ App.on('ready', function() {
 		mainWindow = null;
 	});
 });
-

--- a/index.js
+++ b/index.js
@@ -39,17 +39,21 @@ App.on('ready', function() {
 		e.preventDefault();
 		mainWindow.minimize();
 	});
-	// Upon exiting, dereference the window object so that the GC cleans up.
+	// Load siad
+	var Siad = require('./js/mainjs/initSiad.js')(config, mainWindow);
+	// mainwindow.closed() can only be called when the user quits from the tray.
+	// If the config.siad.detached flag is not set, call siad.stop and quit from the callback.
 	mainWindow.on('closed', function() {
+		if (!config.siad.detached) {
+			Siad.stop(function() {
+				App.quit();
+			});
+		} else {
+			App.quit();
+		}
+		// Dereference mainWindow and Siad to clean up.
+		Siad = null;
 		mainWindow = null;
 	});
-	// Load siad
-	require('./js/mainjs/initSiad.js')(config, mainWindow);
-});
-
-// Quit when the main UI window has been closed.
-App.on('window-all-closed', function() {
-	config.save();
-	App.quit();
 });
 

--- a/index.js
+++ b/index.js
@@ -25,13 +25,11 @@ var config = require('./js/mainjs/config.js')(Path.join(__dirname, 'config.json'
 App.on('ready', function() {
 	// Load mainWindow
 	mainWindow = require('./js/mainjs/initWindow.js')(config);
-	// Load siad
-	require('./js/mainjs/initSiad.js')(config, mainWindow);
 	// Load tray icon and menu
 	var iconPath = Path.join(__dirname, 'assets', 'tray.png');
 	appIcon = new Tray(iconPath);
 	appIcon.setToolTip('Sia - The Collaborative Cloud.');
-	appIcon.setContextMenu(appTray(mainWindow, App));
+	appIcon.setContextMenu(appTray(mainWindow));
 
 	// Add IPCMain listeners
 	require('./js/mainjs/addIPCListeners.js')(config, mainWindow);
@@ -41,9 +39,15 @@ App.on('ready', function() {
 		e.preventDefault();
 		mainWindow.minimize();
 	});
+	// Upon exiting, dereference the window object so that the GC cleans up.
+	mainWindow.on('closed', function() {
+		mainWindow = null;
+	});
+	// Load siad
+	require('./js/mainjs/initSiad.js')(config, mainWindow);
 });
+
 // Quit when the main UI window has been closed.
-// This can only happen when the user has quit the application from the tray.
 App.on('window-all-closed', function() {
 	config.save();
 	App.quit();

--- a/index.js
+++ b/index.js
@@ -34,18 +34,22 @@ App.on('ready', function() {
 	// Add IPCMain listeners
 	require('./js/mainjs/addIPCListeners.js')(config, mainWindow);
 
-	// Catch mainWindow's close event and minimize instead.
-	mainWindow.on('close', function(e) {
-		if (!mainWindow.wantsQuit) {
-			e.preventDefault();
-			mainWindow.minimize();
-		}
-	});
+	// If config.persistInTray is set, catch mainWindow's close event and minimize instead.
+	if (config.persistInTray) {
+		mainWindow.on('close', function(e) {
+			if (!mainWindow.wantsQuit) {
+				e.preventDefault();
+				mainWindow.minimize();
+			}
+		});
+	}
 	// Load siad
 	var Siad = require('./js/mainjs/initSiad.js')(config, mainWindow);
 	// mainwindow.closed() can only be called when the user quits from the tray.
 	// If the config.siad.detached flag is not set, call siad.stop and quit from the callback.
 	mainWindow.on('closed', function() {
+		// save the config on exit
+		config.save();
 		if (!config.siad.detached) {
 			Siad.stop(function() {
 				App.quit();

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var appIcon;
 var config = require('./js/mainjs/config.js')(Path.join(__dirname, 'config.json'));
 
 // When Electron loading has finished, start the daemon then the UI
-App.on('ready', function () {
+App.on('ready', function() {
 	// Load mainWindow
 	mainWindow = require('./js/mainjs/initWindow.js')(config);
 
@@ -39,13 +39,13 @@ App.on('ready', function () {
 	require('./js/mainjs/initSiad.js')(config, mainWindow);
 
 	// Upon exiting, dereference the window object so that the GC cleans up.
-	mainWindow.on('closed', function () {
+	mainWindow.on('closed', function() {
 		mainWindow = null;
 	});
 });
 
 // Quit once all windows have been closed.
-App.on('window-all-closed', function () {
+App.on('window-all-closed', function() {
 	config.save();
 	App.quit();
 });

--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const Path = require('path');
 // garbage collection
 var mainWindow;
 var appIcon;
-var siad;
 
 // config.json manager
 var config = require('./js/mainjs/config.js')(Path.join(__dirname, 'config.json'));
@@ -37,16 +36,16 @@ App.on('ready', function () {
 	require('./js/mainjs/addIPCListeners.js')(config, mainWindow);
 
 	// Load siad
-	siad = require('./js/mainjs/initSiad.js')(config, mainWindow);
+	require('./js/mainjs/initSiad.js')(config, mainWindow);
+
+	// Upon exiting, dereference the window object so that the GC cleans up.
+	mainWindow.on('closed', function () {
+		mainWindow = null;
+	});
 });
+
 // Quit once all windows have been closed.
-// If the config.siad.detached flag is not set, call siad.stop and quit from the callback.
 App.on('window-all-closed', function () {
 	config.save();
-	if (!config.siad.detached) {
-		siad.stop();
-	} 
 	App.quit();
-	mainWindow = null;
-	siad = null;
 });

--- a/js/mainjs/appMenu.js
+++ b/js/mainjs/appMenu.js
@@ -3,7 +3,7 @@
 const Electron = require('electron');
 const Menu = Electron.Menu;
 
-module.exports = function (window) {
+module.exports = function(window) {
 	// Template for OSX app menu commands
 	// Selectors call the main app's NSApplication methods.
 	var menutemplate = [
@@ -33,4 +33,3 @@ module.exports = function (window) {
 
 	return Menu.buildFromTemplate(menutemplate);
 };
-

--- a/js/mainjs/appMenu.js
+++ b/js/mainjs/appMenu.js
@@ -14,7 +14,7 @@ module.exports = function (window) {
 				{ type: 'separator' },
 				{ label: 'Hide Sia', accelerator: 'CmdOrCtrl+H', selector: 'hide:'},
 				{ type: 'separator' },
-				{ label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: function () { window.destroy(); }},
+				{ label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: function() { window.destroy(); }},
 			]
 		},
 		{

--- a/js/mainjs/appMenu.js
+++ b/js/mainjs/appMenu.js
@@ -14,7 +14,7 @@ module.exports = function (window) {
 				{ type: 'separator' },
 				{ label: 'Hide Sia', accelerator: 'CmdOrCtrl+H', selector: 'hide:'},
 				{ type: 'separator' },
-				{ label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: function () { window.close(); }},
+				{ label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: function () { window.destroy(); }},
 			]
 		},
 		{

--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -1,12 +1,13 @@
 'use strict';
 
-// The default settings 
+// The default settings
 const defaultConfig = {
 	homePlugin:  'Overview',
 	siad: {
     	path: require('path').join(__dirname, '../..', 'Sia'),
 		detached: false,
 	},
+	persistInTray: true,
 	width:       800,
 	height:      600,
 	x:           0,
@@ -16,7 +17,7 @@ const defaultConfig = {
 var config;
 
 /**
- * Holds all config.json related logic 
+ * Holds all config.json related logic
  * @module configManager
  */
 function configManager(path) {

--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -7,7 +7,7 @@ const defaultConfig = {
     	path: require('path').join(__dirname, '../..', 'Sia'),
 		detached: false,
 	},
-	persistInTray: true,
+	closeToTray: process.platform === 'win32' || process.platform === 'darwin' ? true : false,
 	width:       800,
 	height:      600,
 	x:           0,

--- a/js/mainjs/initSiad.js
+++ b/js/mainjs/initSiad.js
@@ -75,7 +75,7 @@ function missingSiadDialog() {
 
 // Siad is not running, check if siad doesn't exist at siad.path
 function checkSiadPath() {
-	Fs.stat(config.siad.path, function (err) {
+	Fs.stat(config.siad.path, function(err) {
 		if (!err) {
 			// It's found, start siad
 			startSiad();
@@ -94,7 +94,7 @@ function checkSiadPath() {
 			mainWindow.close();
 			return;
 		}
-		
+
 		// Verify chosen path
 		if (!siadPath) {
 			checkSiadPath();
@@ -111,7 +111,7 @@ module.exports = function initSiad(cnfg, mW) {
 	config = cnfg;
 	mainWindow = mW;
 
-	// Pipe siad events to UI 
+	// Pipe siad events to UI
 	var siadEvents = ['close', 'disconnect', 'error', 'exit', 'message'];
 	siadEvents.forEach(function(ev) {
 		Siad.on(ev, function(arg0, arg1) {
@@ -143,4 +143,3 @@ module.exports = function initSiad(cnfg, mW) {
 		}
 	});
 };
-

--- a/js/mainjs/initSiad.js
+++ b/js/mainjs/initSiad.js
@@ -142,7 +142,5 @@ module.exports = function initSiad(cnfg, mW) {
 			checkSiadPath();
 		}
 	});
-
-	return Siad;
 };
 

--- a/js/mainjs/initSiad.js
+++ b/js/mainjs/initSiad.js
@@ -119,6 +119,18 @@ module.exports = function initSiad(cnfg, mW) {
 		});
 	});
 
+	// Stop siad upon the main window being closed. Else it continues as a
+	// child process of electron, forcing electron to keep running until siad
+	// has stopped
+	mainWindow.on('closed', function() {
+		if (!config.siad.detached) {
+			Siad.stop();
+		}
+		Siad = null;
+		// Also dereference this module's mainWindow instance, since it's closed
+		mainWindow = null;
+	});
+
 	// Set config for Siad to work off of configure() doesn't update
 	// `running` for sia.js:0.1.1 but it should soon from a pending pull
 	// request

--- a/js/mainjs/initSiad.js
+++ b/js/mainjs/initSiad.js
@@ -119,15 +119,14 @@ module.exports = function initSiad(cnfg, mW) {
 		});
 	});
 
-	// Stop siad upon the main window being closed. Else it continues as a
-	// child process of electron, forcing electron to keep running until siad
-	// has stopped
-	mainWindow.on('close', function() {
+	// Closed is called after the main window has been closed.
+	// This can only happen if the user quits from the taskbar.
+	mainWindow.on('closed', function() {
 		if (!config.siad.detached) {
 			Siad.stop();
 		}
 		Siad = null;
-	});
+	}); 
 
 	// Set config for Siad to work off of configure() doesn't update
 	// `running` for sia.js:0.1.1 but it should soon from a pending pull

--- a/js/mainjs/initSiad.js
+++ b/js/mainjs/initSiad.js
@@ -119,16 +119,6 @@ module.exports = function initSiad(cnfg, mW) {
 		});
 	});
 
-	// Stop siad on exit if config.siad.detached isn't set.
-	// Closed is called after the main window has been closed.
-	// This can only happen if the user quits from the taskbar and mainWindow.destroy() is called.
-	mainWindow.on('closed', function() {
-		if (!config.siad.detached) {
-			Siad.stop();
-		}
-		Siad = null;
-	}); 
-
 	// Set config for Siad to work off of configure() doesn't update
 	// `running` for sia.js:0.1.1 but it should soon from a pending pull
 	// request
@@ -140,5 +130,7 @@ module.exports = function initSiad(cnfg, mW) {
 			checkSiadPath();
 		}
 	});
+
+	return Siad;
 };
 

--- a/js/mainjs/initSiad.js
+++ b/js/mainjs/initSiad.js
@@ -119,8 +119,9 @@ module.exports = function initSiad(cnfg, mW) {
 		});
 	});
 
+	// Stop siad on exit if config.siad.detached isn't set.
 	// Closed is called after the main window has been closed.
-	// This can only happen if the user quits from the taskbar.
+	// This can only happen if the user quits from the taskbar and mainWindow.destroy() is called.
 	mainWindow.on('closed', function() {
 		if (!config.siad.detached) {
 			Siad.stop();

--- a/js/mainjs/initWindow.js
+++ b/js/mainjs/initWindow.js
@@ -35,7 +35,7 @@ module.exports = function(config) {
 	// Load the window's size and position
 	mainWindow.setBounds(config);
 
-	// Emitted when the window is closed.
+	// Emitted when the window is closing.
 	mainWindow.on('close', function() {
 		// Save the window's size and position
 		var bounds = mainWindow.getBounds();

--- a/js/mainjs/initWindow.js
+++ b/js/mainjs/initWindow.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
 
 	// Load the window's size and position
 	mainWindow.setBounds(config);
-	
+
 	// Emitted when the window is closed.
 	mainWindow.on('close', function() {
 		// Save the window's size and position
@@ -41,8 +41,9 @@ module.exports = function(config) {
 				config[k] = bounds[k];
 			}
 		}
-
-		// Unregister all shortcuts.
+	});
+	// Unregister all shortcuts when mainWindow is closed.
+	mainWindow.on('closed', function() {
 		GlobalShortcut.unregisterAll();
 	});
 
@@ -57,4 +58,3 @@ module.exports = function(config) {
 	}
 	return mainWindow;
 };
-

--- a/js/mainjs/initWindow.js
+++ b/js/mainjs/initWindow.js
@@ -17,9 +17,9 @@ module.exports = function(config) {
 		icon:   iconPath,
 		title:  'Sia-UI-beta',
 	});
-	// Set mainWindow's persistInTray flag from config.
+	// Set mainWindow's closeToTray flag from config.
 	// This should be used in the renderer to cancel close() events using window.onbeforeunload
-	mainWindow.persistInTray = config.persistInTray;
+	mainWindow.closeToTray = config.closeToTray;
 
 	// Add hotkey shortcut to view plugin devtools
 	var shortcut;

--- a/js/mainjs/initWindow.js
+++ b/js/mainjs/initWindow.js
@@ -17,6 +17,9 @@ module.exports = function(config) {
 		icon:   iconPath,
 		title:  'Sia-UI-beta',
 	});
+	// Set mainWindow's persistInTray flag from config.
+	// This should be used in the renderer to cancel close() events using window.onbeforeunload
+	mainWindow.persistInTray = config.persistInTray;
 
 	// Add hotkey shortcut to view plugin devtools
 	var shortcut;

--- a/js/mainjs/trayMenu.js
+++ b/js/mainjs/trayMenu.js
@@ -8,20 +8,17 @@ module.exports = function (window) {
 	var menutemplate = [
 		{
 			label: 'Show Sia',
-			click: function () { window.restore(); }
+			click: function () { window.show(); }
 		},
 		{ type: 'separator' },
 		{
 			label: 'Hide Sia',
-			click: function () { window.minimize(); }
+			click: function () { window.hide(); }
 		},
 		{ type: 'separator' },
 		{
 			label: 'Quit Sia',
-			click: function() {
-				window.wantsQuit = true;
-				window.close();
-			}
+			click: function() { window.destroy(); }
 		}
 	];
 

--- a/js/mainjs/trayMenu.js
+++ b/js/mainjs/trayMenu.js
@@ -8,13 +8,18 @@ module.exports = function (window) {
 	var menutemplate = [
 		{
 			label: 'Show Sia',
-			click: function () { window.show(); }
+			click: function () { window.restore(); }
 		},
 		{ type: 'separator' },
 		{
 			label: 'Hide Sia',
-			click: function () { window.hide(); }
+			click: function () { window.minimize(); }
 		},
+		{ type: 'separator' },
+		{
+			label: 'Quit Sia',
+			click: function() { window.destroy(); }
+		}
 	];
 
 	return Menu.buildFromTemplate(menutemplate);

--- a/js/mainjs/trayMenu.js
+++ b/js/mainjs/trayMenu.js
@@ -3,7 +3,7 @@
 const Electron = require('electron');
 const Menu = Electron.Menu;
 
-module.exports = function (window) {
+module.exports = function(window) {
 	// Template for Sia-UI tray menu.
 	var menutemplate = [
 		{

--- a/js/mainjs/trayMenu.js
+++ b/js/mainjs/trayMenu.js
@@ -18,10 +18,12 @@ module.exports = function (window) {
 		{ type: 'separator' },
 		{
 			label: 'Quit Sia',
-			click: function() { window.destroy(); }
+			click: function() {
+				window['wantsQuit'] = true;
+				window.close();
+			}
 		}
 	];
 
 	return Menu.buildFromTemplate(menutemplate);
 };
-

--- a/js/mainjs/trayMenu.js
+++ b/js/mainjs/trayMenu.js
@@ -19,7 +19,7 @@ module.exports = function (window) {
 		{
 			label: 'Quit Sia',
 			click: function() {
-				window['wantsQuit'] = true;
+				window.wantsQuit = true;
 				window.close();
 			}
 		}

--- a/js/mainjs/trayMenu.js
+++ b/js/mainjs/trayMenu.js
@@ -8,12 +8,12 @@ module.exports = function (window) {
 	var menutemplate = [
 		{
 			label: 'Show Sia',
-			click: function () { window.show(); }
+			click: function() { window.show(); }
 		},
 		{ type: 'separator' },
 		{
 			label: 'Hide Sia',
-			click: function () { window.hide(); }
+			click: function() { window.hide(); }
 		},
 		{ type: 'separator' },
 		{

--- a/js/rendererjs/.jshintrc
+++ b/js/rendererjs/.jshintrc
@@ -52,7 +52,7 @@
 	"smarttabs"     : false,    // Tolerate mixed tabs and spaces when the latter are used for alignmnent only.
 	"shadow"        : false,    // Allows re-define variables later in code e.g. `var x=1; x=2;`.
 	"sub"           : false,    // Tolerate all forms of subscript notation besides dot notation e.g. `dict['key']` instead of `dict.key`.
-	"supernew"      : false,    // Tolerate `new function () { ... };` and `new Object;`.
+	"supernew"      : false,    // Tolerate `new function() { ... };` and `new Object;`.
 	"validthis"     : false,    // Tolerate strict violations when the code is running in strict mode and you use this in a non-constructor function.
 
 	// == Environments ====================================================

--- a/js/rendererjs/uiManager.js
+++ b/js/rendererjs/uiManager.js
@@ -164,7 +164,7 @@ window.onload = function() {
 };
 
 // Right-click brings up a context menu without blocking the UI
-window.addEventListener('contextmenu', function (e) {
+window.addEventListener('contextmenu', function(e) {
 	e.preventDefault();
 	IPCRenderer.send('context-menu');
 }, false);

--- a/js/rendererjs/uiManager.js
+++ b/js/rendererjs/uiManager.js
@@ -2,6 +2,7 @@
 
 // Imported Electron modules
 const Electron = require('electron');
+const App = Electron.remote.app;
 const IPCRenderer = Electron.ipcRenderer;
 const mainWindow = Electron.remote.getCurrentWindow();
 // Imported Node modules
@@ -139,7 +140,7 @@ function init() {
 }
 
 /**
-* Called at mainWindow.closed(), closes the errorLog
+* Called at app.will-quit, closes the errorLog
 * @function UIManager#kill
 */
 function closeLog() {
@@ -148,7 +149,7 @@ function closeLog() {
 		errorLog.end();
 	}
 }
-mainWindow.on('closed', closeLog);
+App.on('will-quit', closeLog);
 
 // If config.persistInTray is set, hide the window instead of closing the window.
 if (config.persistInTray) {

--- a/js/rendererjs/uiManager.js
+++ b/js/rendererjs/uiManager.js
@@ -152,7 +152,7 @@ App.on('will-quit', closeLog);
 
 // If persistInTray is set, hide the window and cancel the close.
 if (mainWindow.persistInTray) {
-	window.onbeforeunload = function () {
+	window.onbeforeunload = function() {
 		mainWindow.hide();
 		return false;
 	};

--- a/js/rendererjs/uiManager.js
+++ b/js/rendererjs/uiManager.js
@@ -12,7 +12,7 @@ const Siad = require('sia.js');
 const $ = require('jquery');
 // Notification System
 const notification = require('./notificationManager.js');
-// Loading Screen 
+// Loading Screen
 const loadingScreen = require('./loadingScreen');
 
 // Object to export

--- a/js/rendererjs/uiManager.js
+++ b/js/rendererjs/uiManager.js
@@ -15,7 +15,7 @@ const $ = require('jquery');
 const notification = require('./notificationManager.js');
 // Loading Screen
 const loadingScreen = require('./loadingScreen');
-const config = require('../mainjs/config.js')(Path.join(__dirname, 'config.json'));
+const config = require('../mainjs/config.js')(Path.join('../../', __dirname, 'config.json'));
 
 // Object to export
 var ui = {};

--- a/js/rendererjs/uiManager.js
+++ b/js/rendererjs/uiManager.js
@@ -15,7 +15,6 @@ const $ = require('jquery');
 const notification = require('./notificationManager.js');
 // Loading Screen
 const loadingScreen = require('./loadingScreen');
-const config = require('../mainjs/config.js')(Path.join('../../', __dirname, 'config.json'));
 
 // Object to export
 var ui = {};
@@ -151,8 +150,8 @@ function closeLog() {
 }
 App.on('will-quit', closeLog);
 
-// If config.persistInTray is set, hide the window instead of closing the window.
-if (config.persistInTray) {
+// If persistInTray is set, hide the window and cancel the close.
+if (mainWindow.persistInTray) {
 	window.onbeforeunload = function () {
 		mainWindow.hide();
 		return false;

--- a/js/rendererjs/uiManager.js
+++ b/js/rendererjs/uiManager.js
@@ -150,8 +150,8 @@ function closeLog() {
 }
 App.on('will-quit', closeLog);
 
-// If persistInTray is set, hide the window and cancel the close.
-if (mainWindow.persistInTray) {
+// If closeToTray is set, hide the window and cancel the close.
+if (mainWindow.closeToTray) {
 	window.onbeforeunload = function() {
 		mainWindow.hide();
 		return false;

--- a/js/rendererjs/uiManager.js
+++ b/js/rendererjs/uiManager.js
@@ -14,6 +14,7 @@ const $ = require('jquery');
 const notification = require('./notificationManager.js');
 // Loading Screen
 const loadingScreen = require('./loadingScreen');
+const config = require('../mainjs/config.js')(Path.join(__dirname, 'config.json'));
 
 // Object to export
 var ui = {};
@@ -138,7 +139,7 @@ function init() {
 }
 
 /**
-* Called at window.beforeunload, closes the errorLog
+* Called at mainWindow.closed(), closes the errorLog
 * @function UIManager#kill
 */
 function closeLog() {
@@ -147,12 +148,20 @@ function closeLog() {
 		errorLog.end();
 	}
 }
+mainWindow.on('closed', closeLog);
+
+// If config.persistInTray is set, hide the window instead of closing the window.
+if (config.persistInTray) {
+	window.onbeforeunload = function () {
+		mainWindow.hide();
+		return false;
+	};
+}
 
 // Set up responses upon the window loading and closing
 window.onload = function() {
 	loadingScreen(init);
 };
-window.onbeforeunload = closeLog;
 
 // Right-click brings up a context menu without blocking the UI
 window.addEventListener('contextmenu', function (e) {

--- a/plugins/Files/js/folder.js
+++ b/plugins/Files/js/folder.js
@@ -206,14 +206,14 @@ function addGetter(name, getter) {
 
 // Return the names of the files
 Object.defineProperty(folder, 'fileNames', {
-	get: function () {
+	get: function() {
 		return Object.keys(this.files);
 	},
 });
 
 // Return the files object as an array instead
 Object.defineProperty(folder, 'filesArray', {
-	get: function () {
+	get: function() {
 		return this.fileNames.map(name => this.files[name]);
 	},
 });
@@ -225,7 +225,7 @@ var typeError = 'type is neither folder nor file!';
 
 // Return one-dimensional array of all files in this folder
 Object.defineProperty(folder, 'filesArrayDeep', {
-	get: function () {
+	get: function() {
 		var files = [];
 		this.filesArray.forEach(file => {
 			if (file.type === 'folder') {
@@ -242,7 +242,7 @@ Object.defineProperty(folder, 'filesArrayDeep', {
 
 // Calculate sum of file sizes
 Object.defineProperty(folder, 'filesize', {
-	get: function () {
+	get: function() {
 		var sum = 0;
 		this.filesArray.forEach(file => {
 			sum += file.filesize;
@@ -253,7 +253,7 @@ Object.defineProperty(folder, 'filesize', {
 
 // Count the number of files
 Object.defineProperty(folder, 'count', {
-	get: function () {
+	get: function() {
 		return this.filesArrayDeep.length;
 	},
 });
@@ -261,7 +261,7 @@ Object.defineProperty(folder, 'count', {
 // Return one-dimensional array of all siapaths in this folder, used primarily
 // for share and shareascii
 Object.defineProperty(folder, 'paths', {
-	get: function () {
+	get: function() {
 		return this.filesArrayDeep.map(file => file.path);
 	},
 });

--- a/plugins/Files/js/uiTools.js
+++ b/plugins/Files/js/uiTools.js
@@ -90,7 +90,7 @@ module.exports = {
 		var callback = lastParam;
 
 		// Callback iff all calls finished
-		params.push(function () {
+		params.push(function() {
 			if (--count === 0 && callback) {
 				callback();
 			}
@@ -132,7 +132,7 @@ module.exports = {
 		var callback = lastParam;
 
 		// Callback iff all calls finished
-		params.push(function () {
+		params.push(function() {
 			if (--count === 0 && callback) {
 				callback();
 			}

--- a/plugins/Wallet/.jshintrc
+++ b/plugins/Wallet/.jshintrc
@@ -71,7 +71,7 @@
 	"smarttabs"     : false,    // Tolerate mixed tabs and spaces when the latter are used for alignmnent only.
 	"shadow"        : false,    // Allows re-define variables later in code e.g. `var x=1; x=2;`.
 	"sub"           : false,    // Tolerate all forms of subscript notation besides dot notation e.g. `dict['key']` instead of `dict.key`.
-	"supernew"      : false,    // Tolerate `new function () { ... };` and `new Object;`.
+	"supernew"      : false,    // Tolerate `new function() { ... };` and `new Object;`.
 	"validthis"     : false,    // Tolerate strict violations when the code is running in strict mode and you use this in a non-constructor function.
 
 	// == Environments ====================================================


### PR DESCRIPTION
The mainWindow.close event is now overridden and mainWindow.minimize() is called instead.  The only way to quit the application is through the tray menu, all other calls to mainWindow.close() (cmd-Q, the x button, etc) minimize the main window instead.  There is not currently a confirmation dialog.  The previous behavior with config.siad.detached remains intact: quitting the application will not kill siad if this flag is set.
