### PR TITLE
wait for the plugin system to finish loading before showing the UI

### DIFF
--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -37,8 +37,9 @@ const checkSiaPath = () => new Promise((resolve, reject) => {
 const startUI = (welcomeMsg, initUI) => {
 	// Display a welcome message, then initialize the ui
 	overlayText.innerHTML = welcomeMsg;
-	initUI();
-	overlay.style.display = 'none';
+	initUI(() => {
+		overlay.style.display = 'none';
+	});
 };
 
 // startSiad configures and starts a Siad instance.

--- a/js/rendererjs/uiManager.js
+++ b/js/rendererjs/uiManager.js
@@ -129,13 +129,20 @@ function checkUpdate() {
 }
 
 /**
-* Called at window.onload, waits for siad to finish loading to show the UI
+* Called at window.onload, waits for siad and the plugin system to finish loading to show the UI
 * @function UIManager#init
 */
-function init() {
+function init(callback) {
 	// Initialize plugins
 	ui.plugins = require('./pluginManager.js');
-	checkUpdate();
+	// Wait for the plugin system to load, then call callback
+	const loadInterval = setInterval(() => {
+		if (ui.plugins.home.isLoading() === false) {
+			clearInterval(loadInterval);
+			checkUpdate();
+			callback();
+		}
+	}, 500);
 }
 
 /**


### PR DESCRIPTION
This is a minor UX improvement.  The loading screen is now hidden only after the home plugin has finished loading.
