### PR TITLE
Style fixes

### DIFF
--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -28,6 +28,7 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: flex-start;
+	overflow-x: hidden;
 	height: 100%;
 	width: 100%;
 }
@@ -35,7 +36,7 @@
 	width: 400px;
 	height: 100%;
 	box-shadow:inset 0px 0px 0px 1px #00CBA0;
-	overflow-y: scroll;
+	overflow-y: auto;
 	overflow-x: hidden;
 	display: flex;
 	flex-direction: column;
@@ -118,8 +119,12 @@
 	color: #fff;
 	padding-bottom: 10px;
 	padding-top: 10px;
-	padding-left: 20px;
+	padding-left: 5px;
+	padding-right: 5px;
 	overflow: hidden;
+}
+.files-toolbar .buttons div:hover {
+	opacity: 0.5;
 }
 .files-toolbar .buttons div {
 	display: inline-block;
@@ -134,6 +139,7 @@
 	margin-bottom: 2px;
 	font-size: 12px;
 	color: #f5f5f5;
+	user-select: none;
 }
 .files-toolbar .buttons div i {
 	color: #00CBA0;

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -109,6 +109,7 @@
 	padding-bottom: 15px;
 }
 .files-toolbar {
+	min-width: 575px;
 	width: 100%;
 	height: 70px;
 	display: flex;
@@ -119,18 +120,34 @@
 	color: #fff;
 	padding-bottom: 10px;
 	padding-top: 10px;
-	padding-left: 5px;
-	padding-right: 5px;
+	overflow: hidden;
+}
+.set-allowance-button {
+	display: inline-block;
+}
+.search-button {
+	display: inline-block;
+}
+.upload-button {
+	display: inline-block;
+}
+.transfers-button {
+	display: inline-block;
+}
+.files-toolbar .buttons {
 	overflow: hidden;
 }
 .files-toolbar .buttons div:hover {
 	opacity: 0.5;
 }
+.files-usage-info {
+	margin-left: 5px;
+}
 .files-toolbar .buttons div {
-	display: inline-block;
 	text-align: center;
 	margin-bottom: 5px;
 	width: 100px;
+	cursor: pointer;
 }
 .files-toolbar .buttons div span {
 	display: block;
@@ -148,6 +165,7 @@
 	position: absolute;
 	top: 0;
 	right: 10px;
+	cursor: pointer;
 }
 .file-list h2 {
 	text-align: center;
@@ -159,7 +177,7 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: flex-start;
-	overflow-y: scroll;
+	overflow-y: auto;
 	background-color: #C5C5C5;
 	margin: 0;
 }

--- a/plugins/Wallet/css/wallet.css
+++ b/plugins/Wallet/css/wallet.css
@@ -61,7 +61,7 @@
 .transaction-list, .transaction-list table {
 	width: 100%;
 	text-align: center;
-	overflow-y: scroll;
+	overflow-y: auto;
 }
 .transaction-list table td {
 	font-size: 11px;


### PR DESCRIPTION
these style fixes remove blank scrollbars on linux/windows as well as change buttons to `cursor: pointer` and prevent the buttons in the Files plugin from overflowing.
