### PR TITLE
dont set unlocking to false in SET_LOCKED

### DIFF
--- a/plugins/Wallet/js/reducers/wallet.js
+++ b/plugins/Wallet/js/reducers/wallet.js
@@ -35,7 +35,6 @@ export default function walletReducer(state = initialState, action) {
 		return state.set('unlocking', false)
 	case constants.SET_LOCKED:
 		return state.set('unlocked', false)
-                .set('unlocking', false)
 	case constants.SET_UNLOCKED:
 		return state.set('unlocked', true)
                 .set('unlocking', false)


### PR DESCRIPTION
Since getLockStatus is polled in the wallet, polled calls which dispatch setLocked() will interrupt the Wallet's "Unlocking..." dialog.  Fixes #273
