### PR TITLE
pin electron-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-3": "^6.5.0",
     "bignumber.js": "^2.1.3",
-    "electron-prebuilt": "^1.2.2",
+    "electron-prebuilt": "1.2.3",
     "immutable": "^3.8.1",
     "jquery": "^2.1.4",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
version 1.2.4 causes the app to fail to launch.
