### PR TITLE
Patch default siad location for Windows

### DIFF
--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -5,15 +5,15 @@ import Path from 'path'
 const defaultConfig = {
 	homePlugin:  'Overview',
 	siad: {
-		path: Path.join(__dirname, '../Sia/siad'),
+		path: Path.join(__dirname, '../Sia/' + (process.platform === 'win32' ? 'siad.exe' : 'siad')),
 		datadir: Path.join(__dirname, '../Sia'),
 		detached: false,
 	},
 	closeToTray: process.platform === 'win32' || process.platform === 'darwin' ? true : false,
-	width:       800,
-	height:      600,
-	x:           0,
-	y:           0,
+	width:	   1024,
+	height:	  768,
+	x:		   0,
+	y:		   0,
 }
 
 /**


### PR DESCRIPTION
Fixes default search path of siad for Windows users and increases default window size from 800x600px to 1024x768px. Solves issue #260.
