### PR TITLE
only use one instance of config

### DIFF
--- a/js/mainjs/index.js
+++ b/js/mainjs/index.js
@@ -5,7 +5,7 @@ import loadConfig from './config.js'
 import initWindow from './initWindow.js'
 
 // load config.json manager
-const config = loadConfig(Path.join(__dirname, '../config.json'))
+global.config = loadConfig(Path.join(__dirname, '../config.json'))
 let mainWindow
 let appIcon
 // When Electron loading has finished, start Sia-UI.

--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -4,11 +4,9 @@
 import { remote } from 'electron'
 import Siad from 'sia.js'
 import Path from 'path'
-import configLoader from '../mainjs/config.js'
 const dialog = remote.dialog
 const fs = remote.require('fs')
-
-const config = configLoader(Path.join(__dirname, '../config.json'))
+const config = remote.getGlobal('config')
 const siadConfig = config.attr('siad')
 Siad.configure(siadConfig)
 

--- a/js/rendererjs/pluginapi.js
+++ b/js/rendererjs/pluginapi.js
@@ -3,10 +3,9 @@
 import Siad from 'sia.js'
 import Path from 'path'
 import { remote } from 'electron'
-import configLoader from '../mainjs/config.js'
 const dialog = remote.dialog
 const mainWindow = remote.getCurrentWindow()
-const config = configLoader(Path.join(__dirname, '../config.json'))
+const config = remote.getGlobal('config')
 Siad.configure(config.siad)
 
 window.SiaAPI = {

--- a/js/rendererjs/pluginapi.js
+++ b/js/rendererjs/pluginapi.js
@@ -1,7 +1,6 @@
 // pluginapi.js: Sia-UI plugin API interface exposed to all plugins.
 // This is injected into every plugin's global namespace.
 import Siad from 'sia.js'
-import Path from 'path'
 import { remote } from 'electron'
 const dialog = remote.dialog
 const mainWindow = remote.getCurrentWindow()


### PR DESCRIPTION
This fixes the strange racey behavior that has been observed around `config.js`.
