### PR TITLE
add descriptive wallet unlocking text

### DIFF
--- a/plugins/Wallet/js/components/lockscreen.js
+++ b/plugins/Wallet/js/components/lockscreen.js
@@ -21,7 +21,7 @@ const LockScreen = ({unlocked, unlocking, encrypted}) => {
 		)
 	} else if (unlocking) {
 		lockscreenContents = (
-			<span> Unlocking your wallet... </span>
+			<span> Unlocking your wallet, this may take a while (up to several minutes)... </span>
 		)
 	}
 	return (


### PR DESCRIPTION
Wallet unlocking can take a long time.  This PR adds some helpful text to the 'unlocking' screen to increase user sanity.
