### PR TITLE
use electron userData path as the default sia data directory

### DIFF
--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -1,12 +1,13 @@
 import fs from 'fs'
 import Path from 'path'
+import { app } from 'electron'
 
 // The default settings
 const defaultConfig = {
 	homePlugin:  'Overview',
 	siad: {
 		path: Path.join(__dirname, '../Sia/' + (process.platform === 'win32' ? 'siad.exe' : 'siad')),
-		datadir: Path.join(__dirname, '../Sia'),
+		datadir: app.getPath('userData'),
 		detached: false,
 	},
 	closeToTray: process.platform === 'win32' || process.platform === 'darwin' ? true : false,


### PR DESCRIPTION
Implements #243.  Makes #296 easier, since users no longer have to manually migrate their data.
