### PR TITLE
use a filtered average to calculate sane renter price

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "redux-saga": "^0.10.4",
-    "sia.js": "^0.2.0",
+    "sia.js": "^0.2.1",
     "webpack": "^1.13.1"
   },
   "scripts": {

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -149,7 +149,7 @@ export const estimatedStoragePriceH = (hosts) => {
 	}
 
 	// Compute the average host price.
-	// Multiply this median by 9 to assume a redundancy of 6 with 25% of the files being downloaded at 2x monthly price
+	// Multiply this average by 9 to assume a redundancy of 6 with 25% of the files being downloaded at 2x monthly price
 	// TODO: this functionality should be in the api.
 	return hostPrices.sortBy((price) => price.toNumber())
 	                 .take(36)

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -148,12 +148,13 @@ export const estimatedStoragePriceH = (hosts) => {
 		throw 'not enough hosts'
 	}
 
-	// Compute the median host price.
+	// Compute the average host price.
 	// Multiply this median by 9 to assume a redundancy of 6 with 25% of the files being downloaded at 2x monthly price
 	// TODO: this functionality should be in the api.
 	return hostPrices.sortBy((price) => price.toNumber())
 	                 .take(36)
-	                 .get(18)
+	                 .filter((price) => price.lt(SiaAPI.siacoinsToHastings(500000))) // filter outliers
+	                 .reduce((sum, price) => sum.add(price), new BigNumber(0))
 	                 .times(9)
 }
 

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -148,12 +148,13 @@ export const estimatedStoragePriceH = (hosts) => {
 		throw 'not enough hosts'
 	}
 
-	// Compute the average host price.
-	// Multiply this average by 9 to assume a redundancy of 6 with 25% of the files being downloaded at 2x monthly price
+	// Compute the median host price.
+	// Multiply this median by 9 to assume a redundancy of 6 with 25% of the files being downloaded at 2x monthly price
 	// TODO: this functionality should be in the api.
 	return hostPrices.sortBy((price) => price.toNumber())
-	                 .take(36).reduce((sum, price) => sum.add(price), new BigNumber(0))
-	                 .dividedBy(hostPrices.size).times(9)
+	                 .take(36)
+	                 .get(18)
+	                 .times(9)
 }
 
 // Maximum estimated storage is 1TB

--- a/test/files/storageestimation.unit.js
+++ b/test/files/storageestimation.unit.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai'
-import { allowanceStorage, estimatedStoragePriceGBSC } from '../../plugins/Files/js/sagas/helpers.js'
+import { allowanceStorage, estimatedStoragePriceGBSC, estimatedStoragePriceH } from '../../plugins/Files/js/sagas/helpers.js'
 import { List } from 'immutable'
 import Siad from 'sia.js'
+import BigNumber from 'bignumber.js'
 
 global.SiaAPI = {
 	hastingsToSiacoins: Siad.hastingsToSiacoins,
@@ -12,25 +13,31 @@ const size = 10 // 10 gb
 const period = 12000
 
 const hosts = List([
+	{ storageprice: SiaAPI.siacoinsToHastings(22000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(211000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(23000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(21000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(3000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(4000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(5000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(10000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(9000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(10000) },
 	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(200000) },
+	{ storageprice: SiaAPI.siacoinsToHastings(10000) },
+	{ storageprice: SiaAPI.siacoinsToHastings('100000000000000000000') },
+	{ storageprice: SiaAPI.siacoinsToHastings('313373133731337313373') },
+
 ])
 
 describe('storage estimation', () => {
 	it('storage estimation calculations are isomorphic', () => {
 		const priceGBSC = estimatedStoragePriceGBSC(hosts, size, period)
 		expect(allowanceStorage(SiaAPI.siacoinsToHastings(priceGBSC), hosts, period)).to.equal('10 GB')
+	})
+	it('filters outliers', () => {
+		const unfilteredAverage = hosts.reduce((sum, host) => sum.add(host.storageprice), new BigNumber(0)).dividedBy(hosts.size)
+		expect(estimatedStoragePriceH(hosts, 1, 100).lt(unfilteredAverage)).to.be.true
 	})
 })


### PR DESCRIPTION
In the event of outlier hosts with very high prices, the price estimation algorithm returns very inflated prices.  This PR changes that algorithm to filter outlier prices before computing the average.
