### PR TITLE
throw error object with message in storage estimation

### DIFF
--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -145,7 +145,7 @@ export const estimatedStoragePriceH = (hosts) => {
 	const minimumHosts = 14
 	const hostPrices = List(hosts).map((host) => new BigNumber(host.storageprice))
 	if (hostPrices.size < minimumHosts) {
-		throw 'not enough hosts'
+		throw { message: 'not enough hosts' }
 	}
 
 	// Compute the average host price.


### PR DESCRIPTION
Because `showError` sends the error box content `e.message`, the thrown error from `estimatedStoragePriceH` needs to be an object with a `message` key for the thrown error (not enough hosts) to be displayed correctly.
