### PR TITLE
Enforce min window size, remove now redundant min-width in Files

### DIFF
--- a/js/mainjs/initWindow.js
+++ b/js/mainjs/initWindow.js
@@ -28,6 +28,9 @@ export default function(config) {
 	mainWindow.on('move', onBoundsChange(mainWindow, config))
 	mainWindow.on('resize', onBoundsChange(mainWindow, config))
 
+	// Enforce minimum window size.
+	mainWindow.setMinimumSize(1024, 768)
+
 	// Load the index.html of the app.
 	mainWindow.loadURL(Path.join('file://', app.getAppPath(), 'index.html'))
 	// Choose not to show the menubar

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -114,7 +114,6 @@
 	padding-bottom: 15px;
 }
 .files-toolbar {
-	min-width: 650px;
 	width: 100%;
 	height: 70px;
 	display: flex;


### PR DESCRIPTION
Force electron window size to be greater than or equal to 1024 x 768px.
