### PR TITLE
Fix drag file uploads for Files plugin

### DIFF
--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -135,35 +135,35 @@
 	display: inline-block;
 }
 .upload-button:last-of-type {
-    position: absolute;
-    left: 0px;
-    top: 55px;
-    overflow: hidden;
-    padding: 17px 0px 0px;
-    max-height: 0px;
-    background-color: #575757;
-    transition: all 1s .1s;
+	position: absolute;
+	left: 0px;
+	top: 55px;
+	overflow: hidden;
+	padding: 17px 0px 0px;
+	max-height: 0px;
+	background-color: #575757;
+	transition: all 1s .1s;
 }
 .upload-button-container:hover .upload-button:last-of-type {
-    max-height: 100px;
-    padding: 23px 0px 5px;
+	max-height: 100px;
+	padding: 23px 0px 5px;
 } 
 .upload-button-container {
 	display: inline-block;
-    position: relative;
-    top: 0px;
+	position: relative;
+	top: 0px;
 }
 .files-toolbar .buttons div {
-    text-align: center;
-    margin-bottom: 5px;
-    width: 100px;
-    cursor: pointer;
+	text-align: center;
+	margin-bottom: 5px;
+	width: 100px;
+	cursor: pointer;
 }
 .files-toolbar .buttons div {
-    text-align: center;
-    margin-bottom: 5px;
-    width: 100px;
-    cursor: pointer;
+	text-align: center;
+	margin-bottom: 5px;
+	width: 100px;
+	cursor: pointer;
 }
 .transfers-button {
 	display: inline-block;
@@ -284,12 +284,19 @@
 	align-items: center;
 	justify-content: center;
 }
+
+.drag-overlay span {
+	color: #FFFFFF;
+	text-align: center;
+}
 .drag-overlay i {
 	color: #00CBA0;
 }
-.drag-overlay span {
-	color: #FFFFFF;
+.drag-overlay h3 {
+	margin-top: .2em;
+	margin-bottom: 0em;
 }
+
 .upload-dialog {
 	padding-left: 25px;
 	padding-right: 25px;

--- a/plugins/Files/js/components/dragoverlay.js
+++ b/plugins/Files/js/components/dragoverlay.js
@@ -2,8 +2,10 @@ import React from 'react'
 
 const DragOverlay = () => (
 	<div className="drag-overlay">
-		<h3> Upload </h3>
-		<i className="fa fa-cloud-upload fa-3x"></i>
+		<span>
+			<i className="fa fa-cloud-upload fa-3x"></i>
+			<h3>Drag to Upload</h3>
+		</span>
 	</div>
 )
 

--- a/plugins/Files/js/components/filebrowser.js
+++ b/plugins/Files/js/components/filebrowser.js
@@ -18,7 +18,8 @@ const FileBrowser = ({dragging, showUploadDialog, showDeleteDialog, showFileTran
 	const onDrop = (e) => {
 		e.preventDefault()
 		actions.setNotDragging()
-		actions.showUploadDialog(e.dataTransfer.files[0].path)
+		// Convert file list into a list of file paths.
+		actions.showUploadDialog(Array.from(e.dataTransfer.files, (file) => file.path))
 	}
 	const onDragLeave = (e) => {
 		e.preventDefault()

--- a/test/files/uploadtest.js
+++ b/test/files/uploadtest.js
@@ -5,6 +5,7 @@ import { expect } from 'chai'
 import sinon from 'sinon'
 
 import UploadButton from '../../plugins/Files/js/components/uploadbutton.js'
+import FileBrowser from '../../plugins/Files/js/components/filebrowser.js'
 
 const testButton = (files, isDir) => {
 	const uploadSpy = sinon.spy()
@@ -20,6 +21,23 @@ const testButton = (files, isDir) => {
 		uploadButton.find('.upload-button').first().simulate('click')
 	}
 	return {uploadSpy, openFileSpy}
+}
+
+const testDrag = (files) => {
+	const uploadSpy = sinon.spy()
+	const notDraggingSpy = sinon.spy()
+	const testActions = {
+		showUploadDialog: uploadSpy,
+		setNotDragging: notDraggingSpy,
+	}
+	const fileBrowser = shallow(<FileBrowser dragging={false} showUploadDialog={false} showDeleteDialog={false} showFileTransfers={false} actions={testActions} />)
+	fileBrowser.find('.file-browser').first().simulate('drop', {
+		dataTransfer: {
+			files: files.map((file) => ({ path: file }))
+		},
+		preventDefault: () => undefined,
+	})
+	return {uploadSpy, notDraggingSpy}
 }
 
 const testDialog = (files, isDir) => {
@@ -84,6 +102,40 @@ describe('files upload button component', () => {
 		expect(spies.uploadSpy.calledOnce).to.be.true
 		expect(spies.openFileSpy.alwaysCalledWithExactly(siaOpenFoldersArg)).to.be.true
 		expect(spies.openFileSpy.calledOnce).to.be.true
+	})
+})
+
+describe('files drag upload', () => {
+	it('dispatches proper action for a single file drag upload', () => {
+		const testFiles = ['filename.png']
+		const spies = testDrag(testFiles)
+		expect(spies.uploadSpy.alwaysCalledWithExactly(testFiles)).to.be.true
+		expect(spies.uploadSpy.calledOnce).to.be.true
+		expect(spies.notDraggingSpy.calledOnce).to.be.true
+	})
+
+	it('dispatches proper action for a multiple file drag upload', () => {
+		const testFiles = ['filename.png', 'another file name.har', 'yesStillAnotherName.wohoo']
+		const spies = testDrag(testFiles)
+		expect(spies.uploadSpy.alwaysCalledWithExactly(testFiles)).to.be.true
+		expect(spies.uploadSpy.calledOnce).to.be.true
+		expect(spies.notDraggingSpy.calledOnce).to.be.true
+	})
+
+	it('dispatches proper action for a single folder drag upload', () => {
+		const testFiles = ['Awesome Folder']
+		const spies = testDrag(testFiles)
+		expect(spies.uploadSpy.alwaysCalledWithExactly(testFiles)).to.be.true
+		expect(spies.uploadSpy.calledOnce).to.be.true
+		expect(spies.notDraggingSpy.calledOnce).to.be.true
+	})
+
+	it('dispatches proper action for a multiple folder drag upload', () => {
+		const testFiles = ['An amazing Folder', 'Another Amazing Folder', 'Still Another More Amazing Folder']
+		const spies = testDrag(testFiles)
+		expect(spies.uploadSpy.alwaysCalledWithExactly(testFiles)).to.be.true
+		expect(spies.uploadSpy.calledOnce).to.be.true
+		expect(spies.notDraggingSpy.calledOnce).to.be.true
 	})
 })
 


### PR DESCRIPTION
Allows users to drag folder and files onto the Files plugin to upload them. Adds testing to prevent regression of drag functionality and restyles drag overlay.
