### PR TITLE
change statusbar to show synchronizing, not synchronizing, synchronized

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -69,7 +69,7 @@ html,body {
 	margin-left: 5px;
 	margin-right: 5px;
 }
-.status-bar-unsynced i, .status-bar-synced i {
+.status-bar i {
 	margin-right: 10px;
 	margin-left: 10px;
 }

--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -42,11 +42,16 @@ const startUI = (welcomeMsg, initUI) => {
 
 	// Construct the status bar component and poll for updates from Siad
 	setInterval(() => {
-		Siad.call('/consensus', (err, response) => {
-			if (err) {
+		Siad.call('/consensus', (consensusErr, consensusResponse) => {
+			if (consensusErr) {
 				return
 			}
-			ReactDOM.render(<StatusBar synced={response.synced} blockheight={response.height} />, document.getElementById('statusbar'))
+			Siad.call('/gateway', (gatewayErr, gatewayResponse) => {
+				if (gatewayErr) {
+					return
+				}
+				ReactDOM.render(<StatusBar peers={gatewayResponse.peers.length} synced={consensusResponse.synced} blockheight={consensusResponse.height} />, document.getElementById('statusbar'))
+			})
 		})
 	}, 2000)
 	initUI(() => {

--- a/js/rendererjs/statusbar.js
+++ b/js/rendererjs/statusbar.js
@@ -1,18 +1,40 @@
 import React, { PropTypes } from 'react'
 
-const StatusBar = ({synced, blockheight}) => (
-	<div className="status-bar">
-		<div className={synced ? 'status-bar-synced' : 'status-bar-unsynced'}>
-			<i className="fa fa-globe fa-2x"></i>
-			{synced ? 'Synchronized' : 'Not synchronized'}
+const redColor = '#E0000B'
+const greenColor = '#00CBA0'
+const yellowColor = '#E7D414'
+
+const syncStyle = {
+	color: redColor,
+}
+
+const StatusBar = ({synced, blockheight, peers}) => {
+	let status
+	if (!synced && peers === 0) {
+		syncStyle.color = redColor
+		status = 'Not Synchronizing'
+	} else if (!synced && peers > 0) {
+		syncStyle.color = yellowColor
+		status = 'Synchronizing'
+	} else if (synced) {
+		syncStyle.color = greenColor
+		status = 'Synchronized'
+	}
+	return (
+		<div className="status-bar">
+			<div style={syncStyle}>
+				<i className="fa fa-globe fa-2x"></i>
+				{status}
+			</div>
+			<div className="status-bar-blockheight">Block Height: {blockheight}</div>
 		</div>
-		<div className="status-bar-blockheight">Block Height: {blockheight}</div>
-	</div>
-)
+	)
+}
 
 StatusBar.propTypes = {
 	synced: PropTypes.bool.isRequired,
 	blockheight: PropTypes.number.isRequired,
+	peers: PropTypes.number.isRequired,
 }
 
 export default StatusBar


### PR DESCRIPTION
Previoulsy "Not Synchronized" would be shown if `synced` was false, now the UI will show "Not Synchronizing" if there are no peers and consensus is not synced, "Synchronizing" if there are peers and consensus is not synced, and "Synchronized" if consensus is synced.

![screen shot 2016-07-07 at 3 48 50 pm](https://cloud.githubusercontent.com/assets/8183920/16667562/2781749c-445b-11e6-9014-3aa5f88ed712.png)
![screen shot 2016-07-07 at 3 52 35 pm](https://cloud.githubusercontent.com/assets/8183920/16667566/2a4ced3c-445b-11e6-9a76-5d8975b3fe55.png)
![screen shot 2016-07-07 at 3 55 36 pm](https://cloud.githubusercontent.com/assets/8183920/16667588/497eba32-445b-11e6-8519-5633f7853330.png)
