### PR TITLE
Don't convert siafunds from hastings

### DIFF
--- a/plugins/Wallet/js/sagas/helpers.js
+++ b/plugins/Wallet/js/sagas/helpers.js
@@ -48,7 +48,7 @@ const computeTransactionSum = (txn) => {
 	}
 	return {
 		totalSiacoin: SiaAPI.hastingsToSiacoins(totalSiacoinOutput.minus(totalSiacoinInput)),
-		totalSiafund: SiaAPI.hastingsToSiacoins(totalSiafundOutput.minus(totalSiafundInput)),
+		totalSiafund: totalSiafundOutput.minus(totalSiafundInput),
 		totalMiner:   SiaAPI.hastingsToSiacoins(totalMinerOutput.minus(totalMinerInput)),
 	}
 }


### PR DESCRIPTION
`parseRawTransactions` should not treat Siafunds as hastings, doing so results in their value being rounded down to zero.  Fixes #364 
