### PR TITLE
add watchGetContractCount to root files saga

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react", "stage-3"]
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-dom": "^15.0.2",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
-    "redux-saga": "^0.10.4",
+    "redux-saga": "^0.11.0",
     "sia.js": "^0.2.2",
     "webpack": "^1.13.1"
   },

--- a/plugins/Files/js/sagas/index.js
+++ b/plugins/Files/js/sagas/index.js
@@ -16,5 +16,6 @@ export default function* rootSaga() {
 		fork(sagas.watchDeleteFile),
 		fork(sagas.watchUploadFolder),
 		fork(sagas.watchGetStorageMetrics),
+		fork(sagas.watchGetContractCount),
 	]
 }

--- a/test/dom.setup.js
+++ b/test/dom.setup.js
@@ -1,4 +1,5 @@
 import { jsdom } from 'jsdom'
+import 'babel-polyfill'
 
 const exposedProperties = ['window', 'navigator', 'document'];
 

--- a/test/files/files.sagas.js
+++ b/test/files/files.sagas.js
@@ -1,0 +1,43 @@
+import createSagaMiddleware from 'redux-saga'
+import { createStore, applyMiddleware } from 'redux'
+import * as actions from '../../plugins/Files/js/actions/files.js'
+import { expect } from 'chai'
+import { spy } from 'sinon'
+
+import rootSaga from '../../plugins/Files/js/sagas/index.js'
+import rootReducer from '../../plugins/Files/js/reducers/index.js'
+
+const sagaMiddleware = createSagaMiddleware()
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+let contracts = []
+const mockSiaAPI = {
+	call: (uri, callback) => {
+		if (uri === '/renter/contracts') {
+			callback(null, { contracts })
+		}
+	},
+	showError: spy(),
+}
+let store
+
+describe('files plugin sagas', () => {
+	before(() => {
+		global.SiaAPI = mockSiaAPI
+		store = createStore(
+			rootReducer,
+			applyMiddleware(sagaMiddleware)
+		)
+		sagaMiddleware.run(rootSaga)
+	})
+	it('sets contract count on getContractCount', async () => {
+		const contractCount = 36
+		for (let i = 0; i < contractCount; i++) {
+			contracts.push('test' + i)
+		}
+		store.dispatch(actions.getContractCount())
+		await sleep(100)
+		expect(store.getState().files.get('contractCount')).to.equal(contracts.length)
+		expect(SiaAPI.showError.called).to.be.false
+	})
+})

--- a/test/files/storageestimation.unit.js
+++ b/test/files/storageestimation.unit.js
@@ -4,37 +4,38 @@ import { List } from 'immutable'
 import Siad from 'sia.js'
 import BigNumber from 'bignumber.js'
 
-global.SiaAPI = {
-	hastingsToSiacoins: Siad.hastingsToSiacoins,
-	siacoinsToHastings: Siad.siacoinsToHastings,
-}
-
 const size = 10 // 10 gb
 const period = 12000
 
 const hosts = List([
-	{ storageprice: SiaAPI.siacoinsToHastings(22000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(211000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(23000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(21000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(3000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(4000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(5000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(10000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(9000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(10000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(2000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(200000) },
-	{ storageprice: SiaAPI.siacoinsToHastings(10000) },
-	{ storageprice: SiaAPI.siacoinsToHastings('100000000000000000000') },
-	{ storageprice: SiaAPI.siacoinsToHastings('313373133731337313373') },
+	{ storageprice: Siad.siacoinsToHastings(22000) },
+	{ storageprice: Siad.siacoinsToHastings(211000) },
+	{ storageprice: Siad.siacoinsToHastings(23000) },
+	{ storageprice: Siad.siacoinsToHastings(21000) },
+	{ storageprice: Siad.siacoinsToHastings(3000) },
+	{ storageprice: Siad.siacoinsToHastings(4000) },
+	{ storageprice: Siad.siacoinsToHastings(5000) },
+	{ storageprice: Siad.siacoinsToHastings(10000) },
+	{ storageprice: Siad.siacoinsToHastings(9000) },
+	{ storageprice: Siad.siacoinsToHastings(10000) },
+	{ storageprice: Siad.siacoinsToHastings(2000) },
+	{ storageprice: Siad.siacoinsToHastings(200000) },
+	{ storageprice: Siad.siacoinsToHastings(10000) },
+	{ storageprice: Siad.siacoinsToHastings('100000000000000000000') },
+	{ storageprice: Siad.siacoinsToHastings('313373133731337313373') },
 
 ])
 
 describe('storage estimation', () => {
+	before(() => {
+		global.SiaAPI = {
+			hastingsToSiacoins: Siad.hastingsToSiacoins,
+			siacoinsToHastings: Siad.siacoinsToHastings,
+		}
+	})
 	it('storage estimation calculations are isomorphic', () => {
 		const priceGBSC = estimatedStoragePriceGBSC(hosts, size, period)
-		expect(allowanceStorage(SiaAPI.siacoinsToHastings(priceGBSC), hosts, period)).to.equal('10 GB')
+		expect(allowanceStorage(Siad.siacoinsToHastings(priceGBSC), hosts, period)).to.equal('10 GB')
 	})
 	it('filters outliers', () => {
 		const unfilteredAverage = hosts.reduce((sum, host) => sum.add(host.storageprice), new BigNumber(0)).dividedBy(hosts.size)


### PR DESCRIPTION
Previously `GET_CONTRACT_COUNT` actions would not be picked up by the Saga middleware, causing `contractCount` to stay at 0 and not allow users to upload files.

This PR also introduces testing for our sagas, to prevent this from happening again in the future.
