### PR TITLE
ensure every `watch*` saga is run inside the root saga of wallet/files

### DIFF
--- a/plugins/Files/js/sagas/index.js
+++ b/plugins/Files/js/sagas/index.js
@@ -2,20 +2,6 @@ import * as sagas from './files.js'
 import { fork } from 'redux-saga/effects'
 
 export default function* rootSaga() {
-	yield [
-		fork(sagas.watchGetWalletLockstate),
-		fork(sagas.watchGetFiles),
-		fork(sagas.watchSetAllowance),
-		fork(sagas.watchGetWalletBalance),
-		fork(sagas.watchCalculateStorageCost),
-		fork(sagas.watchSetAllowanceProgress),
-		fork(sagas.watchUploadFile),
-		fork(sagas.watchDownloadFile),
-		fork(sagas.watchGetDownloads),
-		fork(sagas.watchGetUploads),
-		fork(sagas.watchDeleteFile),
-		fork(sagas.watchUploadFolder),
-		fork(sagas.watchGetStorageMetrics),
-		fork(sagas.watchGetContractCount),
-	]
+	const watchers = Object.values(sagas).map((saga) => fork(saga))
+	yield watchers
 }

--- a/plugins/Files/js/sagas/index.js
+++ b/plugins/Files/js/sagas/index.js
@@ -2,6 +2,6 @@ import * as sagas from './files.js'
 import { fork } from 'redux-saga/effects'
 
 export default function* rootSaga() {
-	const watchers = Object.values(sagas).map((saga) => fork(saga))
+	const watchers = Object.values(sagas).map(fork)
 	yield watchers
 }

--- a/plugins/Wallet/js/sagas/index.js
+++ b/plugins/Wallet/js/sagas/index.js
@@ -2,14 +2,6 @@ import * as sagas from './wallet.js'
 import { fork } from 'redux-saga/effects'
 
 export default function* rootSaga() {
-	yield [
-		fork(sagas.watchGetLockStatus),
-		fork(sagas.watchUnlockWallet),
-		fork(sagas.watchLockWallet),
-		fork(sagas.watchCreateNewWallet),
-		fork(sagas.watchGetBalance),
-		fork(sagas.watchGetTransactions),
-		fork(sagas.watchGetNewReceiveAddress),
-		fork(sagas.watchSendCurrency),
-	]
+	const watchers = Object.values(sagas).map((saga) => fork(saga))
+	yield watchers
 }

--- a/plugins/Wallet/js/sagas/index.js
+++ b/plugins/Wallet/js/sagas/index.js
@@ -2,6 +2,6 @@ import * as sagas from './wallet.js'
 import { fork } from 'redux-saga/effects'
 
 export default function* rootSaga() {
-	const watchers = Object.values(sagas).map((saga) => fork(saga))
+	const watchers = Object.values(sagas).map(fork)
 	yield watchers
 }

--- a/test/files/files.sagas.js
+++ b/test/files/files.sagas.js
@@ -1,6 +1,7 @@
 import createSagaMiddleware from 'redux-saga'
 import { createStore, applyMiddleware } from 'redux'
 import * as actions from '../../plugins/Files/js/actions/files.js'
+import * as sagas from '../../plugins/Files/js/sagas/files.js'
 import { expect } from 'chai'
 import { spy } from 'sinon'
 
@@ -29,6 +30,9 @@ describe('files plugin sagas', () => {
 			applyMiddleware(sagaMiddleware)
 		)
 		sagaMiddleware.run(rootSaga)
+	})
+	it('runs every watcher saga defined in files', () => {
+		expect(rootSaga().next().value).to.have.length(Object.keys(sagas).length)
 	})
 	it('sets contract count on getContractCount', async () => {
 		const contractCount = 36


### PR DESCRIPTION
This further ensures that every exported saga will be run inside the root saga, preventing bugs similar to #369 from occurring in the future.
