### PR TITLE
Terminal Plugin - Add support for loading 033x wallets and siag files

### DIFF
--- a/plugins/Terminal/js/components/commandinput.js
+++ b/plugins/Terminal/js/components/commandinput.js
@@ -16,7 +16,7 @@ export default class CommandInput extends React.Component {
 			this.props.showCommandOverview, this.props.commandHistory.size)
 		return (
 			<input id="command-input" onChange={handleTextInput} onKeyDown={handleKeyboardPress} type="text"
-				value={this.props.currentCommand} disabled={this.props.ommandRunning} autoFocus autoComplete
+				value={this.props.currentCommand} autoFocus autoComplete
 				ref={(c) => this._input = c}
 			/>
 		)

--- a/plugins/Terminal/js/components/walletpasswordprompt.js
+++ b/plugins/Terminal/js/components/walletpasswordprompt.js
@@ -1,10 +1,9 @@
 import React from 'react'
 import querystring from 'querystring'
-import { httpCommand, commandType } from '../utils/helpers.js'
+import { httpCommand, commandType, getArgumentString } from '../utils/helpers.js'
 import * as constants from '../constants/helper.js'
 
 //This command needs a second prompt.
-const moreSpecialCommands = [ ['wallet', 'load', 'seed'] ]
 export default class WalletPasswordPrompt extends React.Component {
 	componentDidUpdate() {
 		//Give DOM time to register the update.
@@ -17,14 +16,32 @@ export default class WalletPasswordPrompt extends React.Component {
 		const handleTextInput = (e) => this.props.actions.setWalletPassword(e.target.value)
 		const handleKeyboardPress = (e) => {
 			if (e.keyCode === 13) {
-				switch ( commandType(this.props.currentCommand, moreSpecialCommands) ) {
+				switch ( commandType(this.props.currentCommand, constants.specialCommands) ) {
 				case constants.WALLET_SEED:
 					this.props.actions.showSeedPrompt()
 					break
 
+				case constants.WALLET_033X:
+					let options = {
+						'source': getArgumentString(this.props.currentCommand, constants.specialCommands[constants.WALLET_033X]),
+						'encryptionpassword': this.props.walletPassword,
+					}
+				case constants.WALLET_SIAG:
+					options = options || {
+						'keyfiles': getArgumentString(this.props.currentCommand, constants.specialCommands[constants.WALLET_SIAG]),
+						'encryptionpassword': this.props.walletPassword,
+					}
+
+					//Grab input, spawn process, and pipe text field to stdin.
+					let siac = httpCommand(this.props.currentCommand, this.props.actions, this.props.commandHistory.size)
+					siac.write(querystring.stringify(options))
+					siac.end()
+					this.props.actions.setWalletPassword('')
+					break
+
 				default:
 					//Grab input, spawn process, and pipe text field to stdin.
-					const siac = httpCommand(this.props.currentCommand, this.props.actions, this.props.commandHistory.size)
+					siac = httpCommand(this.props.currentCommand, this.props.actions, this.props.commandHistory.size)
 					siac.write(querystring.stringify({ 'encryptionpassword': this.props.walletPassword }))
 					siac.end()
 					this.props.actions.setWalletPassword('')

--- a/plugins/Terminal/js/components/walletpasswordprompt.js
+++ b/plugins/Terminal/js/components/walletpasswordprompt.js
@@ -22,17 +22,20 @@ export default class WalletPasswordPrompt extends React.Component {
 					break
 
 				case constants.WALLET_033X:
+					// Logic for WALLET_033X and WALLET_SIAG is almost identical
+					// use the case fall through to reuse the logic.
 					let options = {
 						'source': getArgumentString(this.props.currentCommand, constants.specialCommands[constants.WALLET_033X]),
 						'encryptionpassword': this.props.walletPassword,
 					}
 				case constants.WALLET_SIAG:
+					// Use the WALLET_SIAG options if we didn't fall through from WALLET_033X.
 					options = options || {
 						'keyfiles': getArgumentString(this.props.currentCommand, constants.specialCommands[constants.WALLET_SIAG]),
 						'encryptionpassword': this.props.walletPassword,
 					}
 
-					//Grab input, spawn process, and pipe text field to stdin.
+					//Grab input, spawn process, and write options.
 					let siac = httpCommand(this.props.currentCommand, this.props.actions, this.props.commandHistory.size)
 					siac.write(querystring.stringify(options))
 					siac.end()
@@ -40,7 +43,7 @@ export default class WalletPasswordPrompt extends React.Component {
 					break
 
 				default:
-					//Grab input, spawn process, and pipe text field to stdin.
+					//Grab input, spawn process, and write password.
 					siac = httpCommand(this.props.currentCommand, this.props.actions, this.props.commandHistory.size)
 					siac.write(querystring.stringify({ 'encryptionpassword': this.props.walletPassword }))
 					siac.end()

--- a/plugins/Terminal/js/constants/helper.js
+++ b/plugins/Terminal/js/constants/helper.js
@@ -1,5 +1,17 @@
 export const REGULAR_COMMAND = -1
 export const WALLET_SEED = 0
 export const WALLET_UNLOCK = 1
-export const HELP = 2
-export const HELP_QMARK = 3
+export const WALLET_033X = 2
+export const WALLET_SIAG = 3
+export const HELP = 4
+export const HELP_QMARK = 5
+
+//These commands need a password prompt or other special handling.
+export const specialCommands = [
+	['wallet', 'load', 'seed'],
+	['wallet', 'unlock'],
+	['wallet', 'load', '033x'],
+	['wallet', 'load', 'siag'],
+	['help'],
+	['?'],
+]

--- a/plugins/Terminal/js/utils/helpers.js
+++ b/plugins/Terminal/js/utils/helpers.js
@@ -190,9 +190,9 @@ export const httpCommand = function(commandStr, actions, newid) {
 		apiURL = '/wallet/unlock'
 	} else if (commandString === 'wallet load seed') {
 		apiURL = '/wallet/seed'
-	} else if (commandString.indexOf('wallet load 033x') === 0) {
+	} else if (commandString.includes('wallet load 033x', 0)) {
 		apiURL = '/wallet/033x'
-	} else if (commandString.indexOf('wallet load siag') === 0) {
+	} else if (commandString.includes('wallet load siag', 0)) {
 		apiURL = '/wallet/siagkey'
 	} else {
 		return spawnCommand(commandString, actions).stdin

--- a/plugins/Terminal/js/utils/helpers.js
+++ b/plugins/Terminal/js/utils/helpers.js
@@ -78,7 +78,7 @@ export const getArgumentString = function(commandString, rawCommandSplit) {
 		if (args[0] === token) {
 			args.shift()
 		} else {
-			console.log(`ERROR: getArgumentString failed, string: ${commandString}, did not contain command: ${rawCommand}`)
+			console.log(`ERROR: getArgumentString failed, string: ${commandString}, did not contain command: ${rawCommandSplit.join(' ')}`)
 			return ''
 		}
 	}
@@ -215,7 +215,7 @@ export const httpCommand = function(commandStr, actions, newid) {
 				buffer = JSON.parse(buffer).message
 			} catch (e) {}
 
-			if (res.statusCode >= 200 && res.statusCode <= 299) {
+			if (res && res.statusCode >= 200 && res.statusCode <= 299) {
 				buffer += 'Success'
 			}
 

--- a/plugins/Terminal/js/utils/helpers.js
+++ b/plugins/Terminal/js/utils/helpers.js
@@ -64,6 +64,36 @@ export const commandType = function(commandString, specialArray) {
 	)
 }
 
+export const getArgumentString = function(commandString, rawCommandSplit) {
+	//Parses out ./siac, siac, command, and address flags leaving only arguments.
+
+	//Remove leading ./siac or siac
+	const args = commandString.replace(/\s*\s/g, ' ').trim().split(' ')
+	if (args[0] === './siac' || args[0] === 'siac') {
+		args.shift()
+	}
+
+	//Remove command from sting.
+	for (const token of rawCommandSplit) {
+		if (args[0] === token) {
+			args.shift()
+		} else {
+			console.log(`ERROR: getArgumentString failed, string: ${commandString}, did not contain command: ${rawCommand}`)
+			return ''
+		}
+	}
+
+	//Strip out address flag.
+	let index = args.indexOf('-a')
+	if  (index === -1) {
+		index = args.indexOf('--address')
+	}
+	if (index !== -1) {
+		args.splice(index, 2)
+	}
+	return args.join(' ')
+}
+
 export const spawnCommand = function(commandStr, actions, newid) {
 	//Create new command object. Id doesn't need to be unique, just can't be the same for adjacent commands.
 
@@ -156,16 +186,15 @@ export const httpCommand = function(commandStr, actions, newid) {
 	}
 
 	let apiURL = ''
-	switch (commandString) {
-	case 'wallet unlock':
+	if (commandString === 'wallet unlock') {
 		apiURL = '/wallet/unlock'
-		break
-
-	case 'wallet load seed':
+	} else if (commandString === 'wallet load seed') {
 		apiURL = '/wallet/seed'
-		break
-
-	default:
+	} else if (commandString.indexOf('wallet load 033x') === 0) {
+		apiURL = '/wallet/033x'
+	} else if (commandString.indexOf('wallet load siag') === 0) {
+		apiURL = '/wallet/siagkey'
+	} else {
 		return spawnCommand(commandString, actions).stdin
 	}
 
@@ -223,20 +252,19 @@ export const httpCommand = function(commandStr, actions, newid) {
 }
 
 export const commandInputHelper = function(e, actions, currentCommand, showCommandOverview, newid) {
-	//These commands need a password prompt or other special handling.
-	const specialCommands = [ ['wallet', 'load', 'seed'], ['wallet', 'unlock'], ['help'], ['?'] ]
-
 	const eventTarget = e.target
 	//Enter button.
 	if (e.keyCode === 13) {
 
 		//Check if command is special.
-		switch ( commandType(currentCommand, specialCommands) ) {
+		switch ( commandType(currentCommand, constants.specialCommands) ) {
 		case constants.REGULAR_COMMAND: //Regular command.
 			spawnCommand(currentCommand, actions, newid) //Spawn command defined in index.js.
 			break
 
 		case constants.WALLET_UNLOCK: //wallet unlock
+		case constants.WALLET_033X: //wallet load 033x
+		case constants.WALLET_SIAG: //wallet load siag
 		case constants.WALLET_SEED: //wallet load seed
 			actions.showWalletPrompt()
 			break


### PR DESCRIPTION
This update routes the calls `wallet load 033x` and `wallet load siag` to the relevant API endpoints to bypass issues we were having with shell-less password entry on Windows in the same method used for the `wallet unlock` and `wallet load seed` commands. This resolves #380.

Right now paths are passed as is to the API endpoint which could lead to confusion due to https://github.com/NebulousLabs/Sia/issues/1385.

Any thoughts on whether it would be a good idea to disallow paths with `~` or relative paths for the Terminal Plugin?
