### PR TITLE
Send Siad SIGKILL when the UI is quit

### DIFF
--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -98,6 +98,9 @@ export default async function loadingScreen(initUI) {
 		siadProcess.on('error', (e) => showError('Siad couldnt start: ' + e.toString()))
 		siadProcess.on('close', () => showError('Siad unexpectedly closed.'))
 		siadProcess.on('exit', () => showError('Siad unexpectedly exited.'))
+
+		// Send the siadProcess a kill signal when Sia-UI is quit.
+		app.on('quit', () => siadProcess.kill('SIGKILL'))
 	} catch (e) {
 		showError(e.toString())
 		return


### PR DESCRIPTION
Nodejs' child_processes can outlive their parents on Linux and OSX, leading to instances of siad outliving users' UIs.  This PR adds a `quit` event listener which sends siad a `SIGKILL`, preventing it from outliving the UI.  This signal is handled in siad (currently by the API package) and triggers a clean shutdown.
