### PR TITLE
do not show `available` files as uploading

### DIFF
--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -114,11 +114,10 @@ export const totalUsage = (files) => readableFilesize(files.reduce((sum, file) =
 // return a list of file uploads
 export const parseUploads = (files) => List(files)
 .filter((file) => file.uploadprogress < 100)
-.filter((file) => !file.available)
 .map((upload) => ({
 	siapath: upload.siapath,
 	name: Path.basename(upload.siapath),
-	progress: Math.floor(upload.uploadprogress),
+	progress: file.available ? 100 : Math.floor(upload.uploadprogress),
 	type: 'upload',
 }))
 .sortBy((upload) => upload.name)

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -114,6 +114,7 @@ export const totalUsage = (files) => readableFilesize(files.reduce((sum, file) =
 // return a list of file uploads
 export const parseUploads = (files) => List(files)
 .filter((file) => file.uploadprogress < 100)
+.filter((file) => !file.available)
 .map((upload) => ({
 	siapath: upload.siapath,
 	name: Path.basename(upload.siapath),


### PR DESCRIPTION
This PR sets the progress of uploads to 100% once they have become available.  This is per a suggestion from @DavidVorick, since uploads almost never reach full redundancy. 
