### PR TITLE
Fix loading bugs

### DIFF
--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -9,7 +9,7 @@ const defaultConfig = {
 		path: Path.join(__dirname, '../Sia/' + (process.platform === 'win32' ? 'siad.exe' : 'siad')),
 		datadir: Path.join(app.getPath('userData'), './sia'),
 		detached: false,
-		address: "localhost:9980",
+		address: 'localhost:9980',
 	},
 	closeToTray: process.platform === 'win32' || process.platform === 'darwin' ? true : false,
 	width:	   1024,

--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -9,6 +9,7 @@ const defaultConfig = {
 		path: Path.join(__dirname, '../Sia/' + (process.platform === 'win32' ? 'siad.exe' : 'siad')),
 		datadir: Path.join(app.getPath('userData'), './sia'),
 		detached: false,
+		address: "localhost:9980",
 	},
 	closeToTray: process.platform === 'win32' || process.platform === 'darwin' ? true : false,
 	width:	   1024,

--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -46,7 +46,7 @@ const startUI = (welcomeMsg, initUI) => {
 // checkSiaPath validates config's Sia path.
 // returns a promise that is resolved with `true` if siadConfig.path exists
 // or `false` if it does not exist.
-const checkSiaPath = () => new Promise((resolve, reject) => {
+const checkSiaPath = () => new Promise((resolve) => {
 	fs.stat(siadConfig.path, (err) => {
 		if (!err) {
 			resolve(true)

--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -51,7 +51,7 @@ const checkSiaPath = () => new Promise((resolve, reject) => {
 		if (!err) {
 			resolve(true)
 		} else {
-			reject(false)
+			resolve(false)
 		}
 	})
 })


### PR DESCRIPTION
this PR fixes two loading bugs introduced after the upgrade to sia.js `0.3.0`: not having a default `Siad.address` in `config.js` would cause the UI to check for a running instance of Sia at the address `undefined`.  In addition, `loadingScreen`'s `checkSiaPath` function would `reject(false)` instead of `resolve(false)`, causing an unhandled promise rejection and not returning the correct `false` `running` boolean.
