### PR TITLE
fix a few instances of spaces-for-indentation in the terminal plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "babel-core": "^6.16.0",
     "babel-eslint": "^6.0.4",
+    "babel-register": "^6.16.3",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
     "electron-packager": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "A UI application for interfacing with Sia",
   "license": "MIT",
   "devDependencies": {
+    "babel-core": "^6.16.0",
     "babel-eslint": "^6.0.4",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",

--- a/plugins/Terminal/js/reducers/commandline.js
+++ b/plugins/Terminal/js/reducers/commandline.js
@@ -71,7 +71,7 @@ export default function commandLineReducer(state = initialState, action) {
 		return state.set('currentCommand', action.command)
 
 	case constants.SET_WALLET_PASSWORD:
-		   return state.set('walletPassword', action.walletPassword)
+		return state.set('walletPassword', action.walletPassword)
 
 	case constants.SHOW_WALLET_PROMPT:
 		return state.set('showWalletPrompt', true)

--- a/plugins/Terminal/js/utils/helpers.js
+++ b/plugins/Terminal/js/utils/helpers.js
@@ -8,15 +8,15 @@ import * as constants from '../constants/helper.js'
 
 export const checkSiaPath = () => new Promise((resolve, reject) => {
 	fs.stat(SiaAPI.config.attr('siac').path, (err) => {
-		 if (!err) {
+		if (!err) {
 			if (Path.basename(SiaAPI.config.attr('siac').path).indexOf('siac') !== -1) {
 				resolve()
 			} else {
 				reject({ message: 'Invalid binary name.' })
 			}
-		 } else {
+		} else {
 			reject(err)
-		 }
+		}
 	})
 })
 
@@ -288,7 +288,7 @@ export const commandInputHelper = function(e, actions, currentCommand, showComma
 		default:
 			break
 		}
-	 } else if (e.keyCode === 38) {
+	} else if (e.keyCode === 38) {
 		//Up arrow.
 		actions.loadPrevCommand(eventTarget.value)
 		setTimeout( () => {


### PR DESCRIPTION
eslint was updated, revealing a few instances in the terminal plugin where spaces were used for indentation instead of tabs.  This should fix the failing build
