### PR TITLE
call .displayBalloon correctly on windows

### DIFF
--- a/js/mainjs/index.js
+++ b/js/mainjs/index.js
@@ -1,5 +1,4 @@
-import { app, Tray } from 'electron'
-import appTray from './trayMenu.js'
+import { app } from 'electron'
 import Path from 'path'
 import loadConfig from './config.js'
 import initWindow from './initWindow.js'
@@ -7,15 +6,11 @@ import initWindow from './initWindow.js'
 // load config.json manager
 global.config = loadConfig(Path.join(__dirname, '../config.json'))
 let mainWindow
-let appIcon
 
 // When Electron loading has finished, start Sia-UI.
 app.on('ready', () => {
 	// Load mainWindow
 	mainWindow = initWindow(config)
-	appIcon = new Tray(Path.join(app.getAppPath(), 'assets', 'tray.png'))
-	appIcon.setToolTip('Sia - The Collaborative Cloud.')
-	appIcon.setContextMenu(appTray(mainWindow))
 })
 
 // Allow only one instance of Sia-UI

--- a/js/mainjs/initWindow.js
+++ b/js/mainjs/initWindow.js
@@ -1,5 +1,6 @@
-import { Menu, BrowserWindow, app } from 'electron'
+import { Menu, BrowserWindow, Tray, app } from 'electron'
 import appMenu from './appMenu.js'
+import appTray from './trayMenu.js'
 import Path from 'path'
 
 // Save window position and bounds every time the window is moved or resized.
@@ -22,6 +23,10 @@ export default function(config) {
 	// Set mainWindow's closeToTray flag from config.
 	// This should be used in the renderer to cancel close() events using window.onbeforeunload
 	mainWindow.closeToTray = config.closeToTray
+
+	mainWindow.tray = new Tray(Path.join(app.getAppPath(), 'assets', 'tray.png'))
+	mainWindow.tray.setToolTip('Sia - The Collaborative Cloud.')
+	mainWindow.tray.setContextMenu(appTray(mainWindow))
 
 	// Load the window's size and position
 	mainWindow.setBounds(config)

--- a/js/rendererjs/index.js
+++ b/js/rendererjs/index.js
@@ -6,7 +6,6 @@ import { remote, ipcRenderer } from 'electron'
 import { scanFolder, unloadPlugins, loadPlugin, setCurrentPlugin, getPluginName } from './plugins.js'
 
 const App = remote.app
-const Tray = remote.Tray
 const mainWindow = remote.getCurrentWindow()
 const defaultPluginDirectory = Path.join(App.getAppPath(), './plugins')
 const defaultHomePlugin = 'Files'
@@ -97,7 +96,7 @@ window.onbeforeunload = () => {
 	if (window.closeToTray) {
 		mainWindow.hide()
 		if (process.platform === 'win32' && !hasClosed) {
-			Tray.displayBalloon({
+			mainWindow.tray.displayBalloon({
 				title: 'Sia-UI information',
 				content: 'Sia is still running.  Right click this tray icon to quit or restore Sia.',
 			})


### PR DESCRIPTION
this PR fixes a bug in windows where `Sia-UI` will unexpectedly quit on close instead of minimizing to the tray, caused by calling `Tray.displayBalloon` on the exported electron `Tray` object instead of the tray object instantiated by the UI.
