### PR TITLE
remove uploads from upload list once they reach >99% progress

### DIFF
--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -113,7 +113,7 @@ export const totalUsage = (files) => readableFilesize(files.reduce((sum, file) =
 // Parse a list of files from `/renter/files`
 // return a list of file uploads
 export const parseUploads = (files) => List(files)
-.filter((file) => file.uploadprogress < 100)
+.filter((file) => file.uploadprogress < 99)
 .map((upload) => ({
 	siapath: upload.siapath,
 	name: Path.basename(upload.siapath),

--- a/test/files/files.sagas.js
+++ b/test/files/files.sagas.js
@@ -193,6 +193,12 @@ describe('files plugin sagas', () => {
 		await sleep(10)
 		expect(store.getState().files.get('uploading')).to.deep.equal(testUploads)
 		expect(SiaAPI.showError.called).to.be.false
+		testUploads = [
+		]
+		store.dispatch(actions.getUploads())
+		await sleep(10)
+		expect(store.getState().files.get('uploading')).to.deep.equal(testUploads)
+		expect(SiaAPI.showError.called).to.be.false
 	})
 	it('sets downloads on getDownloads', async () => {
 		testDownloads = [

--- a/test/files/helpers.js
+++ b/test/files/helpers.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { readableFilesize, ls } from '../../plugins/Files/js/sagas/helpers.js'
+import { parseUploads, readableFilesize, ls } from '../../plugins/Files/js/sagas/helpers.js'
 import { List } from 'immutable'
 
 describe('files plugin helper functions', () => {
@@ -60,4 +60,25 @@ describe('files plugin helper functions', () => {
 			expect(output.toObject()).to.deep.equal(expectedOutputs[path].toObject())
 		}
 	})
+	it('filters uploads correctly in parseUploads', () => {
+		expect(parseUploads([
+			{uploadprogress: 50, siapath: 'test', available: true},
+			{uploadprogress: 50, siapath: 'test', available: true},
+			{uploadprogress: 100, siapath: 'test', available: true},
+			{uploadprogress: 100, siapath: 'test', available: true},
+		]).size).to.equal(2)
+		expect(parseUploads([
+			{uploadprogress: 100, siapath: 'test', available: true},
+			{uploadprogress: 100, siapath: 'test', available: true},
+			{uploadprogress: 100, siapath: 'test', available: true},
+			{uploadprogress: 100, siapath: 'test', available: true},
+		]).size).to.equal(0)
+		expect(parseUploads([
+			{uploadprogress: 99.8, siapath: 'test', available: true},
+			{uploadprogress: 99.5, siapath: 'test', available: true},
+			{uploadprogress: 50, siapath: 'test', available: true},
+			{uploadprogress: 50, siapath: 'test', available: true},
+		]).size).to.equal(2)
+	})
 })
+


### PR DESCRIPTION
Due to some rounding problems, some uploads never reach exactly 100%. This causes them to stay in the upload list unexpectedly, as observed in #402. This PR changes `parseUploads` to filter out files that have more than 99% progress, instead of the previous 100% progress.
