### PR TITLE
Improve resizing behavior

### DIFF
--- a/js/mainjs/initWindow.js
+++ b/js/mainjs/initWindow.js
@@ -33,9 +33,6 @@ export default function(config) {
 	mainWindow.on('move', onBoundsChange(mainWindow, config))
 	mainWindow.on('resize', onBoundsChange(mainWindow, config))
 
-	// Enforce minimum window size.
-	mainWindow.setMinimumSize(1024, 768)
-
 	// Load the index.html of the app.
 	mainWindow.loadURL(Path.join('file://', app.getAppPath(), 'index.html'))
 	// Choose not to show the menubar

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -116,6 +116,7 @@
 .files-toolbar {
 	width: 100%;
 	height: 70px;
+	min-width: 500px;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;


### PR DESCRIPTION
This PR adds a `min-width` property to the files plugin toolbar, preventing it from overflowing and breaking layout when the window is small. This also removes the minimum window size, since that has proven to be a problem on certain (mostly linux) systems. Fixes #404
