### PR TITLE
improve wallet CSS

### DIFF
--- a/plugins/Wallet/css/wallet.css
+++ b/plugins/Wallet/css/wallet.css
@@ -66,6 +66,9 @@
 .transaction-list table td {
 	font-size: 11px;
 }
+.txid {
+	font-family: monospace;
+}
 .transaction-list table th {
 	font-size: 14px;
 	text-align: center;

--- a/plugins/Wallet/js/components/transactionlist.js
+++ b/plugins/Wallet/js/components/transactionlist.js
@@ -25,7 +25,7 @@ const TransactionList = ({transactions}) => {
 		}
 		return (
 			<tr key={key}>
-				<td className="txval">{valueData}</td>
+				<td>{valueData}</td>
 				<td className="txid">{txn.transactionid}</td>
 				<td>{txn.confirmed ? <i className="fa fa-check-square confirmed-icon"> Confirmed </i> : <i className="fa fa-clock-o unconfirmed-icon"> Unconfirmed </i>}</td>
 			</tr>

--- a/plugins/Wallet/js/components/transactionlist.js
+++ b/plugins/Wallet/js/components/transactionlist.js
@@ -25,8 +25,8 @@ const TransactionList = ({transactions}) => {
 		}
 		return (
 			<tr key={key}>
-				<td>{valueData}</td>
-				<td>{txn.transactionid}</td>
+				<td className="txval">{valueData}</td>
+				<td className="txid">{txn.transactionid}</td>
 				<td>{txn.confirmed ? <i className="fa fa-check-square confirmed-icon"> Confirmed </i> : <i className="fa fa-clock-o unconfirmed-icon"> Unconfirmed </i>}</td>
 			</tr>
 		)


### PR DESCRIPTION
This PR improves the wallet plugin's styling by monospacing the transaction id and value in the transaction list, making transaction IDs and values line up visually.
