### PR TITLE
add timeouts, timeout error handling

### DIFF
--- a/js/rendererjs/pluginapi.js
+++ b/js/rendererjs/pluginapi.js
@@ -47,15 +47,10 @@ window.onload = async function() {
 
 
 window.SiaAPI = {
-	call: async function(url, callback) {
-		let results
-		let error
-		try {
-			results = await Siad.call(siadConfig.address, url)
-		} catch (e) {
-			error = e
-		}
-		callback(error, results)
+	call: function(url, callback) {
+		Siad.call(siadConfig.address, url)
+		    .then((res) => callback(null, res))
+				.catch((err) => callback(err, null))
 	},
 	config: config,
 	hastingsToSiacoins: Siad.hastingsToSiacoins,

--- a/js/rendererjs/pluginapi.js
+++ b/js/rendererjs/pluginapi.js
@@ -48,17 +48,14 @@ window.onload = async function() {
 
 window.SiaAPI = {
 	call: async function(url, callback) {
-		const running = await Siad.isRunning(siadConfig.address)
-		if (running) {
-			let results
-			let error
-			try {
-				results = await Siad.call(siadConfig.address, url)
-			} catch (e) {
-				error = e
-			}
-			callback(error, results)
+		let results
+		let error
+		try {
+			results = await Siad.call(siadConfig.address, url)
+		} catch (e) {
+			error = e
 		}
+		callback(error, results)
 	},
 	config: config,
 	hastingsToSiacoins: Siad.hastingsToSiacoins,

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -5,7 +5,7 @@ import fs from 'fs'
 import * as actions from '../actions/files.js'
 import * as constants from '../constants/files.js'
 import { List } from 'immutable'
-import { ls, allowancePeriod, allowanceHosts, estimatedStorage, totalSpending, handleError, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
+import { ls, allowancePeriod, allowanceHosts, estimatedStorage, totalSpending, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
 
 
 // Query siad for the state of the wallet.

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -15,11 +15,7 @@ function* getWalletLockstateSaga() {
 		const response = yield siadCall('/wallet')
 		yield put(actions.receiveWalletLockstate(response.unlocked))
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		sendError(e)
+		console.error('error fetching wallet lock state: ' + e.toString())
 	}
 }
 
@@ -30,11 +26,7 @@ function* getFilesSaga() {
 		const files = List(response.files)
 		yield put(actions.receiveFiles(files))
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		sendError(e)
+		console.error('error fetching files: ' + e.toString())
 	}
 }
 
@@ -61,11 +53,7 @@ function* getAllowanceSaga() {
 		yield put(actions.receiveAllowance(allowance.round(0).toString()))
 		yield put(actions.receiveSpending(spendingSC.round(0).toString()))
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		console.error(e)
+		console.error('error getting allowance: ' + e.toString())
 	}
 }
 
@@ -77,6 +65,7 @@ function* setAllowanceSaga(action) {
 		yield siadCall({
 			url: '/renter',
 			method: 'POST',
+			timeout: 18000000, // 30 minute timeout for setting allowance
 			qs: {
 				funds: newAllowance.toString(),
 				hosts: allowanceHosts,
@@ -98,7 +87,7 @@ function* getWalletBalanceSaga() {
 		const confirmedBalance = SiaAPI.hastingsToSiacoins(response.confirmedsiacoinbalance).round(2).toString()
 		yield put(actions.receiveWalletBalance(confirmedBalance))
 	} catch (e) {
-		sendError(e)
+		console.error('error fetching wallet balance: ' + e.toString())
 	}
 }
 
@@ -112,6 +101,7 @@ function* uploadFileSaga(action) {
 		const destpath = Path.posix.join(action.siapath, filename)
 		yield siadCall({
 			url: '/renter/upload/' + encodeURI(destpath),
+			timeout: 20000, // 20 second timeout for upload calls
 			method: 'POST',
 			qs: {
 				source: action.source,
@@ -144,6 +134,7 @@ function* downloadFileSaga(action) {
 		if (action.file.type === 'file') {
 			yield siadCall({
 				url: '/renter/download/' + encodeURI(action.file.siapath),
+				timeout: 60000,
 				method: 'GET',
 				qs: {
 					destination: action.downloadpath,
@@ -171,11 +162,7 @@ function* getDownloadsSaga() {
 		const downloads = parseDownloads(response.downloads)
 		yield put(actions.receiveDownloads(downloads))
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		sendError(e)
+		console.error('error fetching downloads: ' + e.toString())
 	}
 }
 
@@ -185,11 +172,7 @@ function* getUploadsSaga() {
 		const uploads = parseUploads(response.files)
 		yield put(actions.receiveUploads(uploads))
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		sendError(e)
+		console.error('error fetching uploads: ' + e.toString())
 	}
 }
 
@@ -198,6 +181,7 @@ function* deleteFileSaga(action) {
 		if (action.file.type === 'file') {
 			yield siadCall({
 				url: '/renter/delete/' + encodeURI(action.file.siapath),
+				timeout: 10000,
 				method: 'POST',
 			})
 		}
@@ -220,11 +204,7 @@ function* getContractCountSaga() {
 		const response = yield siadCall('/renter/contracts')
 		yield put(actions.setContractCount(response.contracts.length))
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		sendError(e)
+		console.error('error getting contract count: ' + e.toString())
 	}
 }
 

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -5,7 +5,7 @@ import fs from 'fs'
 import * as actions from '../actions/files.js'
 import * as constants from '../constants/files.js'
 import { List } from 'immutable'
-import { ls, allowancePeriod, allowanceHosts, estimatedStorage, totalSpending, sendError, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
+import { ls, allowancePeriod, allowanceHosts, estimatedStorage, totalSpending, handleError, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
 
 
 // Query siad for the state of the wallet.
@@ -15,7 +15,7 @@ function* getWalletLockstateSaga() {
 		const response = yield siadCall('/wallet')
 		yield put(actions.receiveWalletLockstate(response.unlocked))
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -26,7 +26,7 @@ function* getFilesSaga() {
 		const files = List(response.files)
 		yield put(actions.receiveFiles(files))
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -73,7 +73,7 @@ function* setAllowanceSaga(action) {
 		})
 		yield put(actions.setAllowanceCompleted())
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 		yield put(actions.setAllowanceCompleted())
 		yield put(actions.closeAllowanceDialog())
 	}
@@ -86,7 +86,7 @@ function* getWalletBalanceSaga() {
 		const confirmedBalance = SiaAPI.hastingsToSiacoins(response.confirmedsiacoinbalance).round(2).toString()
 		yield put(actions.receiveWalletBalance(confirmedBalance))
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -106,7 +106,7 @@ function* uploadFileSaga(action) {
 			},
 		})
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -123,7 +123,7 @@ function *uploadFolderSaga(action) {
 			yield put(uploads.get(upload))
 		}
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -149,7 +149,7 @@ function* downloadFileSaga(action) {
 			}
 		}
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -159,7 +159,7 @@ function* getDownloadsSaga() {
 		const downloads = parseDownloads(response.downloads)
 		yield put(actions.receiveDownloads(downloads))
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -169,7 +169,7 @@ function* getUploadsSaga() {
 		const uploads = parseUploads(response.files)
 		yield put(actions.receiveUploads(uploads))
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -191,7 +191,7 @@ function* deleteFileSaga(action) {
 		}
 		yield put(actions.getFiles())
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -200,7 +200,7 @@ function* getContractCountSaga() {
 		const response = yield siadCall('/renter/contracts')
 		yield put(actions.setContractCount(response.contracts.length))
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 
@@ -228,7 +228,7 @@ function* renameFileSaga(action) {
 		}
 		yield put(actions.hideRenameDialog())
 	} catch (e) {
-		sendError(e)
+		handleError(e)
 	}
 }
 

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -65,7 +65,7 @@ function* setAllowanceSaga(action) {
 		yield siadCall({
 			url: '/renter',
 			method: 'POST',
-			timeout: 18000000, // 30 minute timeout for setting allowance
+			timeout: 7.2e6, // 120 minute timeout for setting allowance
 			qs: {
 				funds: newAllowance.toString(),
 				hosts: allowanceHosts,
@@ -134,7 +134,7 @@ function* downloadFileSaga(action) {
 		if (action.file.type === 'file') {
 			yield siadCall({
 				url: '/renter/download/' + encodeURI(action.file.siapath),
-				timeout: 600000000,
+				timeout: 6e8,
 				method: 'GET',
 				qs: {
 					destination: action.downloadpath,

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -15,7 +15,11 @@ function* getWalletLockstateSaga() {
 		const response = yield siadCall('/wallet')
 		yield put(actions.receiveWalletLockstate(response.unlocked))
 	} catch (e) {
-		handleError(e)
+		if (isConnectionError(e)) {
+			console.error('siad communication error: ' + e.toString())
+			return
+		}
+		sendError(e)
 	}
 }
 
@@ -26,7 +30,11 @@ function* getFilesSaga() {
 		const files = List(response.files)
 		yield put(actions.receiveFiles(files))
 	} catch (e) {
-		handleError(e)
+		if (isConnectionError(e)) {
+			console.error('siad communication error: ' + e.toString())
+			return
+		}
+		sendError(e)
 	}
 }
 
@@ -53,6 +61,10 @@ function* getAllowanceSaga() {
 		yield put(actions.receiveAllowance(allowance.round(0).toString()))
 		yield put(actions.receiveSpending(spendingSC.round(0).toString()))
 	} catch (e) {
+		if (isConnectionError(e)) {
+			console.error('siad communication error: ' + e.toString())
+			return
+		}
 		console.error(e)
 	}
 }
@@ -73,7 +85,7 @@ function* setAllowanceSaga(action) {
 		})
 		yield put(actions.setAllowanceCompleted())
 	} catch (e) {
-		handleError(e)
+		sendError(e)
 		yield put(actions.setAllowanceCompleted())
 		yield put(actions.closeAllowanceDialog())
 	}
@@ -86,7 +98,7 @@ function* getWalletBalanceSaga() {
 		const confirmedBalance = SiaAPI.hastingsToSiacoins(response.confirmedsiacoinbalance).round(2).toString()
 		yield put(actions.receiveWalletBalance(confirmedBalance))
 	} catch (e) {
-		handleError(e)
+		sendError(e)
 	}
 }
 
@@ -106,7 +118,7 @@ function* uploadFileSaga(action) {
 			},
 		})
 	} catch (e) {
-		handleError(e)
+		sendError(e)
 	}
 }
 
@@ -123,7 +135,7 @@ function *uploadFolderSaga(action) {
 			yield put(uploads.get(upload))
 		}
 	} catch (e) {
-		handleError(e)
+		sendError(e)
 	}
 }
 
@@ -149,7 +161,7 @@ function* downloadFileSaga(action) {
 			}
 		}
 	} catch (e) {
-		handleError(e)
+		sendError(e)
 	}
 }
 
@@ -159,7 +171,11 @@ function* getDownloadsSaga() {
 		const downloads = parseDownloads(response.downloads)
 		yield put(actions.receiveDownloads(downloads))
 	} catch (e) {
-		handleError(e)
+		if (isConnectionError(e)) {
+			console.error('siad communication error: ' + e.toString())
+			return
+		}
+		sendError(e)
 	}
 }
 
@@ -169,7 +185,11 @@ function* getUploadsSaga() {
 		const uploads = parseUploads(response.files)
 		yield put(actions.receiveUploads(uploads))
 	} catch (e) {
-		handleError(e)
+		if (isConnectionError(e)) {
+			console.error('siad communication error: ' + e.toString())
+			return
+		}
+		sendError(e)
 	}
 }
 
@@ -191,7 +211,7 @@ function* deleteFileSaga(action) {
 		}
 		yield put(actions.getFiles())
 	} catch (e) {
-		handleError(e)
+		sendError(e)
 	}
 }
 
@@ -200,7 +220,11 @@ function* getContractCountSaga() {
 		const response = yield siadCall('/renter/contracts')
 		yield put(actions.setContractCount(response.contracts.length))
 	} catch (e) {
-		handleError(e)
+		if (isConnectionError(e)) {
+			console.error('siad communication error: ' + e.toString())
+			return
+		}
+		sendError(e)
 	}
 }
 
@@ -228,7 +252,7 @@ function* renameFileSaga(action) {
 		}
 		yield put(actions.hideRenameDialog())
 	} catch (e) {
-		handleError(e)
+		sendError(e)
 	}
 }
 

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -134,7 +134,7 @@ function* downloadFileSaga(action) {
 		if (action.file.type === 'file') {
 			yield siadCall({
 				url: '/renter/download/' + encodeURI(action.file.siapath),
-				timeout: 60000,
+				timeout: 600000000,
 				method: 'GET',
 				qs: {
 					destination: action.downloadpath,

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -13,12 +13,8 @@ export const baseRedundancy = 6
 export const baseFee = 240
 export const siafundRate = 0.12
 
-// handleError handles an error given by e.
-export const handleError = (e) => {
-	if (typeof e.code !== 'undefined' && e.code === 'ETIMEDOUT') {
-		// NOP on timeouts.
-		return
-	}
+// sendError sends the error given by e to the ui for display.
+export const sendError = (e) => {
 	SiaAPI.showError({
 		title: 'Sia-UI Files Error',
 		content: e.message,

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -17,7 +17,7 @@ export const siafundRate = 0.12
 export const sendError = (e) => {
 	SiaAPI.showError({
 		title: 'Sia-UI Files Error',
-		content: e.message,
+		content: typeof e.message !== 'undefined' ? e.message : e.toString(),
 	})
 }
 

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -13,7 +13,12 @@ export const baseRedundancy = 6
 export const baseFee = 240
 export const siafundRate = 0.12
 
-export const sendError = (e) => {
+// handleError handles an error given by e.
+export const handleError = (e) => {
+	if (typeof e.code !== 'undefined' && e.code === 'ETIMEDOUT') {
+		// NOP on timeouts.
+		return
+	}
 	SiaAPI.showError({
 		title: 'Sia-UI Files Error',
 		content: e.message,

--- a/plugins/Hosting/js/sagas/saga.js
+++ b/plugins/Hosting/js/sagas/saga.js
@@ -18,6 +18,14 @@ const siadCall = (uri) => new Promise((resolve, reject) => {
 	})
 })
 
+const isConnectionError = (e) =>
+	e.code !== 'undefined' &&
+		(e.code === 'ECONNREFUSED' ||
+		 e.code === 'ECONNRESET' ||
+		 e.code === 'ETIMEDOUT' ||
+		 e.code === 'EPIPE')
+
+
 const fetchStorageFiles = () => new Promise((resolve, reject) => {
 	siadCall({
 		url: '/host/storage',
@@ -169,7 +177,8 @@ function *fetchData(action) {
 
 		yield put( actions.fetchDataSuccess(data, settings, modals) )
 	} catch (e) {
-		if (typeof e.code !== 'undefined' && e.code === 'ETIMEDOUT') {
+		if (isConnectionError(e)) {
+			console.error('siad communication error: ' + e.toString())
 			return
 		}
 		SiaAPI.showError({ title: 'Error Fetching Data', content: e.message })

--- a/plugins/Hosting/js/sagas/saga.js
+++ b/plugins/Hosting/js/sagas/saga.js
@@ -18,14 +18,6 @@ const siadCall = (uri) => new Promise((resolve, reject) => {
 	})
 })
 
-const isConnectionError = (e) =>
-	e.code !== 'undefined' &&
-		(e.code === 'ECONNREFUSED' ||
-		 e.code === 'ECONNRESET' ||
-		 e.code === 'ETIMEDOUT' ||
-		 e.code === 'EPIPE')
-
-
 const fetchStorageFiles = () => new Promise((resolve, reject) => {
 	siadCall({
 		url: '/host/storage',
@@ -48,6 +40,7 @@ function *announceHost(action) {
 		if (closeAction.address !== '') { //If size is zero just hide the dialog.
 			yield siadCall({
 				url: '/host/announce',
+				timeout: 30000, // 30 second timeout for host announcement
 				method: 'POST',
 				qs: { netaddress: closeAction.address },
 			})
@@ -177,11 +170,7 @@ function *fetchData(action) {
 
 		yield put( actions.fetchDataSuccess(data, settings, modals) )
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		SiaAPI.showError({ title: 'Error Fetching Data', content: e.message })
+		console.error('error fetching host data: ' + e.toString())
 	}
 }
 

--- a/plugins/Hosting/js/sagas/saga.js
+++ b/plugins/Hosting/js/sagas/saga.js
@@ -30,10 +30,7 @@ const fetchStorageFiles = () => new Promise((resolve, reject) => {
 				free: (new BigNumber(file.capacityremaining)).times('1e-9').toString(),
 			})
 		))))
-	}).catch( (e) => {
-		SiaAPI.showError({ title: 'Error Fetching Folders', content: e.message })
-		reject(e)
-	})
+	}).catch(reject)
 })
 
 function *announceHost(action) {
@@ -172,6 +169,9 @@ function *fetchData(action) {
 
 		yield put( actions.fetchDataSuccess(data, settings, modals) )
 	} catch (e) {
+		if (typeof e.code !== 'undefined' && e.code === 'ETIMEDOUT') {
+			return
+		}
 		SiaAPI.showError({ title: 'Error Fetching Data', content: e.message })
 	}
 }

--- a/plugins/Wallet/js/sagas/wallet.js
+++ b/plugins/Wallet/js/sagas/wallet.js
@@ -8,8 +8,8 @@ import { walletUnlockError } from '../actions/error.js'
 // Send an error notification.
 const sendError = (e) => {
 	SiaAPI.showError({
-		title: 'Sia-UI Wallet Error',
-		content: e.message,
+	title: 'Sia-UI Wallet Error',
+		content: typeof e.message !== 'undefined' ? e.message : e.toString(),
 	})
 }
 

--- a/plugins/Wallet/js/sagas/wallet.js
+++ b/plugins/Wallet/js/sagas/wallet.js
@@ -13,13 +13,6 @@ const sendError = (e) => {
 	})
 }
 
-const isConnectionError = (e) =>
-	e.code !== 'undefined' &&
-		(e.code === 'ECONNREFUSED' ||
-		 e.code === 'ECONNRESET' ||
-		 e.code === 'ETIMEDOUT' ||
-		 e.code === 'EPIPE')
-
 // Wallet plugin sagas
 // Sagas are an elegant way of handling asynchronous side effects.
 // All side effects logic is contained entirely in this file.
@@ -40,11 +33,7 @@ function *getLockStatusSaga() {
 			yield put(actions.setUnencrypted())
 		}
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		sendError(e)
+		console.error('error fetching lock status: ' + e.toString())
 	}
 }
 
@@ -112,11 +101,7 @@ function *getBalanceSaga() {
 		const unconfirmed = unconfirmedIncoming.minus(unconfirmedOutgoing)
 		yield put(actions.setBalance(confirmed.round(2).toString(), unconfirmed.round(2).toString(), response.siafundbalance))
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		sendError(e)
+		console.error('error fetching balance: ' + e.toString())
 	}
 }
 
@@ -127,11 +112,7 @@ function *getTransactionsSaga() {
 		const transactions = parseRawTransactions(response)
 		yield put(actions.setTransactions(transactions))
 	} catch (e) {
-		if (isConnectionError(e)) {
-			console.error('siad communication error: ' + e.toString())
-			return
-		}
-		sendError(e)
+		console.error('error fetching transactions: ' + e.toString())
 	}
 }
 // Call /wallet/address, set the receive address, and show the receive prompt.

--- a/plugins/Wallet/js/sagas/wallet.js
+++ b/plugins/Wallet/js/sagas/wallet.js
@@ -8,7 +8,7 @@ import { walletUnlockError } from '../actions/error.js'
 // Send an error notification.
 const sendError = (e) => {
 	SiaAPI.showError({
-	title: 'Sia-UI Wallet Error',
+		title: 'Sia-UI Wallet Error',
 		content: typeof e.message !== 'undefined' ? e.message : e.toString(),
 	})
 }

--- a/release.sh
+++ b/release.sh
@@ -77,10 +77,11 @@ buildLinux() {
 	mkdir resources/app
 	(
 		cd resources/app
-		wget $siaLinux
-		unzip ./Sia-*
-		rm ./Sia*.zip
-		mv ./Sia-* ./Sia
+		mkdir Sia
+		cp `which siad` Sia/siad
+		cp `which siac` Sia/siac
+		chmod +x Sia/siad
+		chmod +x Sia/siac
 	)
 	package "../../" "resources/app"
 	rm -r electron*.zip

--- a/release.sh
+++ b/release.sh
@@ -77,11 +77,10 @@ buildLinux() {
 	mkdir resources/app
 	(
 		cd resources/app
-		mkdir Sia
-		cp `which siad` Sia/siad
-		cp `which siac` Sia/siac
-		chmod +x Sia/siad
-		chmod +x Sia/siac
+		wget $siaLinux
+		unzip ./Sia-*
+		rm ./Sia*.zip
+		mv ./Sia-* ./Sia
 	)
 	package "../../" "resources/app"
 	rm -r electron*.zip


### PR DESCRIPTION
This PR coincides with https://github.com/NebulousLabs/Nodejs-Sia/pull/36; it changes all polling API requests to log errors to console instead of popping up error dialogs, preventing timeouts from causing unwanted error messaging.  I also cleaned up the plugin API's `call` wrapper function, and added some sane default timeouts for long running requests (wallet unlocking, downloading, etc). 
