### PR TITLE
do not allow negative spending amounts in usage stats

### DIFF
--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -37,7 +37,11 @@ export const siadCall = (uri) => new Promise((resolve, reject) => {
 // including fees. Allowance should be a bignumber of SC.
 export const totalSpending = (allowance, contracts) => {
 	const totalRenterPayouts = contracts.reduce((sum, contract) => sum.plus(SiaAPI.hastingsToSiacoins(contract.renterfunds)), new BigNumber(0))
-	return allowance.minus(totalRenterPayouts)
+	let spending = allowance.minus(totalRenterPayouts)
+	if (spending.lt(0)) {
+		spending = new BigNumber(0)
+	}
+	return spending
 }
 
 // Take a number of bytes and return a sane, human-readable size.


### PR DESCRIPTION
If the renter overspends the allowance, negative spending will appear in the user's usage stats. This PR changes `totalSpending` to return a minimum of `0`.
