### PR TITLE
use current time as timestamp if transaction is not confirmed

### DIFF
--- a/plugins/Wallet/js/components/transactionlist.js
+++ b/plugins/Wallet/js/components/transactionlist.js
@@ -35,7 +35,7 @@ const TransactionList = ({transactions, ntransactions, actions}) => {
 		}
 		return (
 			<tr key={key}>
-				<td>{prettyTimestamp(txn.confirmationtimestamp)}</td>
+				<td>{txn.confirmed ? prettyTimestamp(txn.confirmationtimestamp) : 'Not Confirmed'}</td>
 				<td>{valueData}</td>
 				<td className="txid">{txn.transactionid}</td>
 				<td>{txn.confirmed ? <i className="fa fa-check-square confirmed-icon"> Confirmed </i> : <i className="fa fa-clock-o unconfirmed-icon"> Unconfirmed </i>}</td>

--- a/plugins/Wallet/js/sagas/helpers.js
+++ b/plugins/Wallet/js/sagas/helpers.js
@@ -76,7 +76,7 @@ export const parseRawTransactions = (response) => {
 			confirmed,
 			transactionsums,
 			transactionid: txn.transactionid,
-			confirmationtimestamp: new Date(txn.confirmationtimestamp*1000),
+			confirmationtimestamp: txn.confirmed ? new Date(txn.confirmationtimestamp*1000) : new Date(),
 		}
 	}))
 	// Return the transactions, sorted by timestamp.

--- a/plugins/Wallet/js/sagas/helpers.js
+++ b/plugins/Wallet/js/sagas/helpers.js
@@ -76,7 +76,7 @@ export const parseRawTransactions = (response) => {
 			confirmed,
 			transactionsums,
 			transactionid: txn.transactionid,
-			confirmationtimestamp: txn.confirmed ? new Date(txn.confirmationtimestamp*1000) : new Date(),
+			confirmationtimestamp: new Date(txn.confirmationtimestamp*1000),
 		}
 	}))
 	// Return the transactions, sorted by timestamp.


### PR DESCRIPTION
This fixes unconfirmed transactions having `NaN NaN NaN` timestamps
