### PR TITLE
move terminal questionmark further from scrollbars

### DIFF
--- a/plugins/Terminal/css/style.css
+++ b/plugins/Terminal/css/style.css
@@ -99,7 +99,7 @@ footer {
 .help-button {
 	position: absolute;
 	top: 0px;
-	right: 15px;
+	right: 25px;
 	background-color: #00CBA0;
 	color: #FFF;
 	cursor: pointer;


### PR DESCRIPTION
Scroll bars a bit larger on windows than I remembered.
