### PR TITLE
make upload, rename, and delete file api calls serial

### DIFF
--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -1,5 +1,5 @@
 import { takeEvery } from 'redux-saga'
-import { put } from 'redux-saga/effects'
+import { put, actionChannel, take } from 'redux-saga/effects'
 import Path from 'path'
 import fs from 'fs'
 import * as actions from '../actions/files.js'
@@ -251,7 +251,11 @@ export function* watchGetFiles() {
 	yield *takeEvery(constants.GET_FILES, getFilesSaga)
 }
 export function* watchDeleteFile() {
-	yield *takeEvery(constants.DELETE_FILE, deleteFileSaga)
+	const deleteChan = yield actionChannel(constants.DELETE_FILE)
+	while (true) {
+		const deleteAction = yield take(deleteChan)
+		yield *deleteFileSaga(deleteAction)
+	}
 }
 export function* watchGetWalletBalance() {
 	yield *takeEvery(constants.GET_WALLET_BALANCE, getWalletBalanceSaga)
@@ -263,13 +267,21 @@ export function* watchGetContractCount() {
 	yield *takeEvery(constants.GET_CONTRACT_COUNT, getContractCountSaga)
 }
 export function* watchUploadFile() {
-	yield *takeEvery(constants.UPLOAD_FILE, uploadFileSaga)
+	const uploadChan = yield actionChannel(constants.UPLOAD_FILE)
+	while (true) {
+		const uploadAction = yield take(uploadChan)
+		yield *uploadFileSaga(uploadAction)
+	}
 }
 export function* watchDownloadFile() {
 	yield *takeEvery(constants.DOWNLOAD_FILE, downloadFileSaga)
 }
 export function* watchRenameFile() {
-	yield *takeEvery(constants.RENAME_FILE, renameFileSaga)
+	const renameChan = yield actionChannel(constants.RENAME_FILE)
+	while (true) {
+		const renameAction = yield take(renameChan)
+		yield *renameFileSaga(renameAction)
+	}
 }
 export function* watchGetStorageEstimate() {
 	yield *takeEvery(constants.GET_STORAGE_ESTIMATE, getStorageEstimateSaga)


### PR DESCRIPTION
This PR introduces an `actionChannel` to the Files plugin, making upload, rename, and delete API calls occur serially. This fixes a bug found by wskeen, reported in slack. Ideally download calls would also be serial, but they are currently blocking calls in the API.

fixes #455