### PR TITLE
replace back button with directory info bar

### DIFF
--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -286,7 +286,7 @@ div[tabindex="1"]:focus {
 	align-items: center;
 	justify-content: flex-start;
 }
-.file-list li:hover {
+.filebrowser-file:hover {
 	background-color: #F5F5F5;
 }
 .file-list li i {

--- a/plugins/Files/js/components/directoryinfobar.js
+++ b/plugins/Files/js/components/directoryinfobar.js
@@ -13,8 +13,8 @@ const DirectoryInfoBar = ({path, nfiles, onBackClick}) => {
 		})(),
 	}
 	return (
-		<li onClick={onBackClick}>
-			<div>
+		<li className="directory-infobar">
+			<div style={{cursor: 'pointer'}} className="back-button" onClick={onBackClick}>
 				<i className="fa fa-backward" style={backButtonStyle} />
 				<span>Back</span>
 			</div>

--- a/plugins/Files/js/components/directoryinfobar.js
+++ b/plugins/Files/js/components/directoryinfobar.js
@@ -1,0 +1,35 @@
+import React, { PropTypes } from 'react'
+
+const colorBackDisabled = '#C5C5C5'
+const colorBackEnabled = '#00CBA0'
+
+const DirectoryInfoBar = ({path, nfiles, onBackClick}) => {
+	const backButtonStyle = {
+		color: (() => {
+			if (path === '') {
+				return colorBackDisabled
+			}
+			return colorBackEnabled
+		})(),
+	}
+	return (
+		<li onClick={onBackClick}>
+			<div>
+				<i className="fa fa-backward" style={backButtonStyle} />
+				<span>Back</span>
+			</div>
+			<div className="directory-info">
+				<span style={{marginRight: '10px'}}> {path} </span>
+				<span style={{marginRight: '10px'}}> {nfiles} {nfiles === 1 ? 'file' : 'files' }</span>
+			</div>
+		</li>
+	)
+}
+
+DirectoryInfoBar.propTypes = {
+	path: PropTypes.string.isRequired,
+	nfiles: PropTypes.number.isRequired,
+	onBackClick: PropTypes.func.isRequired,
+}
+
+export default DirectoryInfoBar

--- a/plugins/Files/js/components/filelist.js
+++ b/plugins/Files/js/components/filelist.js
@@ -4,6 +4,7 @@ import File from './file.js'
 import Path from 'path'
 import SearchField from '../containers/searchfield.js'
 import FileControls from '../containers/filecontrols.js'
+import DirectoryInfoBar from './directoryinfobar.js'
 
 const FileList = ({files, selected, searchResults, path, showSearchField, actions}) => {
 	const onBackClick = () => {
@@ -16,7 +17,6 @@ const FileList = ({files, selected, searchResults, path, showSearchField, action
 		}
 		actions.setPath(newpath)
 	}
-
 	let filelistFiles
 	if (showSearchField) {
 		filelistFiles = searchResults
@@ -85,7 +85,7 @@ const FileList = ({files, selected, searchResults, path, showSearchField, action
 		<div className="file-list">
 			{showSearchField ? <SearchField /> : null}
 			<ul>
-				{path !== '' ? <li onClick={onBackClick}><div><i className="fa fa-backward" />Back</div></li> : null}
+				<DirectoryInfoBar path={path} nfiles={files.size} onBackClick={onBackClick} />
 				{fileElements.size > 0 ? fileElements : (showSearchField ? <h2> No matching files </h2> : <h2> No files uploaded </h2>)}
 			</ul>
 			{selected.size > 0 ? <FileControls /> : null}

--- a/test/files/filelist.component.js
+++ b/test/files/filelist.component.js
@@ -81,7 +81,7 @@ describe('file list', () => {
 		expect(testActions.setPath.calledWith('test1/')).to.equal(true)
 
 		filelist = mount(<FileList files={testFiles} showSearchField={false} selected={OrderedSet()} path="test1/" actions={testActions} />)
-		filelist.find('ul').children().first().simulate('click')
+		filelist.find('.back-button').first().simulate('click')
 		expect(testActions.setPath.calledWith('')).to.equal(true)
 
 		const renderedDirectories = filelist.find('File [type="directory"]')

--- a/test/files/filelist.component.js
+++ b/test/files/filelist.component.js
@@ -77,7 +77,7 @@ describe('file list', () => {
 	})
 	it('navigates directories', () => {
 		let filelist = mount(<FileList files={testFiles} selected={OrderedSet()} showSearchField={false} path="test1/test2/" actions={testActions} />)
-		filelist.find('ul').children().first().simulate('click')
+		filelist.find('.back-button').first().simulate('click')
 		expect(testActions.setPath.calledWith('test1/')).to.equal(true)
 
 		filelist = mount(<FileList files={testFiles} showSearchField={false} selected={OrderedSet()} path="test1/" actions={testActions} />)

--- a/test/files/filelist.component.js
+++ b/test/files/filelist.component.js
@@ -76,7 +76,7 @@ describe('file list', () => {
 		})
 	})
 	it('navigates directories', () => {
-		let filelist = shallow(<FileList files={testFiles} selected={OrderedSet()} showSearchField={false} path="test1/test2/" actions={testActions} />)
+		let filelist = mount(<FileList files={testFiles} selected={OrderedSet()} showSearchField={false} path="test1/test2/" actions={testActions} />)
 		filelist.find('ul').children().first().simulate('click')
 		expect(testActions.setPath.calledWith('test1/')).to.equal(true)
 


### PR DESCRIPTION
This PR adds a new component, `DirectoryInfoBar`, that replaces the back button in the file list. This bar is always the first element of the list. It shows the current path along with the number of files in the current directory, and a back button. The back button is greyed out if the user is in the root directory. This fixes the issue where double-clicking the back button would trigger a doubleclick event on a folder in the parent directory, causing the user to go back and forward in quick succession.