### PR TITLE
add notification badge on download or upload

### DIFF
--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -209,14 +209,38 @@ div[tabindex="1"]:focus {
 	width: 100px;
 	cursor: pointer;
 }
-.files-toolbar .buttons div {
-	text-align: center;
-	margin-bottom: 5px;
-	width: 100px;
-	cursor: pointer;
-}
 .transfers-button {
 	display: inline-block;
+}
+
+@keyframes notify-animation {
+	from {
+		right: 50%;
+		top: 50%;
+		width: 100px;
+		height: 100px;
+		font-size: 28px;
+		text-align: center;
+	}
+	to {
+		right: 25px;
+		top: 5px;
+		width: 13px;
+		height: 13px;
+		font-size: 12px;
+	}
+}
+
+.transfers-button > .badge {
+	background: rgba(255, 0, 0, 0.5);
+	border-radius: 50%;
+	position: absolute;
+	top: 5px;
+	right: 25px;
+	width: 13px;
+	height: 13px;
+	animation-name: notify-animation;
+	animation-duration: 0.5s;
 }
 .files-toolbar .buttons div[class$="button"]:hover {
 	opacity: 0.5;

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -9,6 +9,7 @@
  *	Grey-Black: #4A4A4A
  *	Black:	  #000000
  *	Neon-Green: #00CBA0
+ *	Venetian-Red: #CC0033
  */
 
 .app {
@@ -225,7 +226,7 @@ div[tabindex="1"]:focus {
 }
 
 .transfers-button > .badge {
-	background: rgba(255, 0, 0, 0.8);
+	background: #CC0033;
 	border-radius: 50%;
 	position: absolute;
 	top: 5px;

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -215,30 +215,28 @@ div[tabindex="1"]:focus {
 
 @keyframes notify-animation {
 	from {
-		right: 50%;
-		top: 50%;
-		width: 100px;
-		height: 100px;
-		font-size: 28px;
-		text-align: center;
+		width: 40px;
+		height: 40px;
 	}
 	to {
-		right: 25px;
-		top: 5px;
-		width: 13px;
-		height: 13px;
-		font-size: 12px;
+		width: 20px;
+		height: 20px;
 	}
 }
 
 .transfers-button > .badge {
-	background: rgba(255, 0, 0, 0.5);
+	background: rgba(255, 0, 0, 0.8);
 	border-radius: 50%;
 	position: absolute;
 	top: 5px;
 	right: 25px;
-	width: 13px;
-	height: 13px;
+	width: 20px;
+	height: 20px;
+	vertical-align: center;
+	display: flex !important;
+	align-items: center;
+	justify-content: center;
+	font-size: 11px;
 	animation-name: notify-animation;
 	animation-duration: 0.5s;
 }

--- a/plugins/Files/js/components/transfersbutton.js
+++ b/plugins/Files/js/components/transfersbutton.js
@@ -5,7 +5,9 @@ const FileTransfersButton = ({unread, actions}) => {
 	return (
 		<div className="transfers-button" onClick={onTransfersClick}>
 			<i className="fa fa-bars fa-2x" />
-			{unread > 0 ? <span className="badge" key={unread}>{unread}</span> : null}
+			{unread > 0 ? (
+				<span className="badge" key={unread}>{unread > 10 ? '10+' : unread}</span>
+				) : null}
 			<span>File Transfers</span>
 		</div>
 	)

--- a/plugins/Files/js/components/transfersbutton.js
+++ b/plugins/Files/js/components/transfersbutton.js
@@ -1,13 +1,18 @@
-import React from 'react'
+import React, { PropTypes } from 'react'
 
-const FileTransfersButton = ({actions}) => {
+const FileTransfersButton = ({unread, actions}) => {
 	const onTransfersClick = () => actions.toggleFileTransfers()
 	return (
 		<div className="transfers-button" onClick={onTransfersClick}>
 			<i className="fa fa-bars fa-2x" />
+			{unread > 0 ? <span className="badge" key={unread}>{unread}</span> : null}
 			<span>File Transfers</span>
 		</div>
 	)
+}
+
+FileTransfersButton.propTypes = {
+	unread: PropTypes.number.isRequired,
 }
 
 export default FileTransfersButton

--- a/plugins/Files/js/containers/transfersbutton.js
+++ b/plugins/Files/js/containers/transfersbutton.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux'
 import { toggleFileTransfers } from '../actions/files.js'
 
 const mapStateToProps = (state) => ({
-	unread: state.files.get('unreadTransfers'),
+	unread: state.files.get('unreadTransfers').size,
 })
 const mapDispatchToProps = (dispatch) => ({
 	actions: bindActionCreators({ toggleFileTransfers }, dispatch),

--- a/plugins/Files/js/containers/transfersbutton.js
+++ b/plugins/Files/js/containers/transfersbutton.js
@@ -3,7 +3,8 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { toggleFileTransfers } from '../actions/files.js'
 
-const mapStateToProps = () => ({
+const mapStateToProps = (state) => ({
+	unread: state.files.get('unreadTransfers'),
 })
 const mapDispatchToProps = (dispatch) => ({
 	actions: bindActionCreators({ toggleFileTransfers }, dispatch),

--- a/plugins/Files/js/containers/transfersbutton.js
+++ b/plugins/Files/js/containers/transfersbutton.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from 'redux'
 import { toggleFileTransfers } from '../actions/files.js'
 
 const mapStateToProps = (state) => ({
-	unread: state.files.get('unreadTransfers').size,
+	unread: state.files.get('unreadUploads').size + state.files.get('unreadDownloads').size,
 })
 const mapDispatchToProps = (dispatch) => ({
 	actions: bindActionCreators({ toggleFileTransfers }, dispatch),

--- a/plugins/Files/js/reducers/files.js
+++ b/plugins/Files/js/reducers/files.js
@@ -98,7 +98,8 @@ export default function filesReducer(state = initialState, action) {
 		return state.set('unreadTransfers', state.get('unreadTransfers').intersect(action.uploads.map((upload) => upload.siapath).toSet()))
 		            .set('uploading', action.uploads)
 	case constants.RECEIVE_DOWNLOADS:
-		return state.set('downloading', action.downloads.filter((download) => Date.parse(download.starttime) > state.get('showDownloadsSince')))
+		return state.set('unreadTransfers', state.get('unreadTransfers').intersect(action.downloads.map((download) => download.siapath).toSet()))
+		            .set('downloading', action.downloads.filter((download) => Date.parse(download.starttime) > state.get('showDownloadsSince')))
 	case constants.SHOW_FILE_TRANSFERS:
 		return state.set('showFileTransfers', true)
 		            .set('unreadTransfers', Set())

--- a/plugins/Files/js/reducers/files.js
+++ b/plugins/Files/js/reducers/files.js
@@ -26,7 +26,8 @@ const initialState = Map({
 	storageEstimate: '',
 	feeEstimate: 0,
 	showDownloadsSince: Date.now(),
-	unreadTransfers: Set(),
+	unreadUploads: Set(),
+	unreadDownloads: Set(),
 })
 
 export default function filesReducer(state = initialState, action) {
@@ -42,9 +43,9 @@ export default function filesReducer(state = initialState, action) {
 	case constants.SET_FEE_ESTIMATE:
 		return state.set('feeEstimate', action.estimate)
 	case constants.DOWNLOAD_FILE:
-		return state.set('unreadTransfers', state.get('unreadTransfers').add(action.file.siapath))
+		return state.set('unreadDownloads', state.get('unreadDownloads').add(action.file.siapath))
 	case constants.UPLOAD_FILE:
-		return state.set('unreadTransfers', state.get('unreadTransfers').add(action.siapath))
+		return state.set('unreadUploads', state.get('unreadUploads').add(action.siapath))
 	case constants.RECEIVE_FILES:
 		const workingDirectoryFiles = ls(action.files, state.get('path'))
 		const workingDirectorySiapaths = workingDirectoryFiles.map((file) => file.siapath)
@@ -95,18 +96,19 @@ export default function filesReducer(state = initialState, action) {
 	case constants.HIDE_UPLOAD_DIALOG:
 		return state.set('showUploadDialog', false)
 	case constants.RECEIVE_UPLOADS:
-		return state.set('unreadTransfers', state.get('unreadTransfers').intersect(action.uploads.map((upload) => upload.siapath).toSet()))
+		return state.set('unreadUploads', state.get('unreadUploads').intersect(action.uploads.map((upload) => upload.siapath).toSet()))
 		            .set('uploading', action.uploads)
 	case constants.RECEIVE_DOWNLOADS:
-		return state.set('unreadTransfers', state.get('unreadTransfers').intersect(action.downloads.map((download) => download.siapath).toSet()))
+		return state.set('unreadDownloads', state.get('unreadDownloads').intersect(action.downloads.map((download) => download.siapath).toSet()))
 		            .set('downloading', action.downloads.filter((download) => Date.parse(download.starttime) > state.get('showDownloadsSince')))
 	case constants.SHOW_FILE_TRANSFERS:
 		return state.set('showFileTransfers', true)
-		            .set('unreadTransfers', Set())
 	case constants.HIDE_FILE_TRANSFERS:
 		return state.set('showFileTransfers', false)
 	case constants.TOGGLE_FILE_TRANSFERS:
 		return state.set('showFileTransfers', !state.get('showFileTransfers'))
+		            .set('unreadDownloads', Set())
+		            .set('unreadUploads', Set())
 	case constants.SET_CONTRACT_COUNT:
 		return state.set('contractCount', action.count)
 	case constants.SHOW_RENAME_DIALOG:

--- a/plugins/Files/js/reducers/files.js
+++ b/plugins/Files/js/reducers/files.js
@@ -26,6 +26,7 @@ const initialState = Map({
 	storageEstimate: '',
 	feeEstimate: 0,
 	showDownloadsSince: Date.now(),
+	unreadTransfers: 0,
 })
 
 export default function filesReducer(state = initialState, action) {
@@ -40,6 +41,10 @@ export default function filesReducer(state = initialState, action) {
 		return state.set('storageEstimate', action.estimate)
 	case constants.SET_FEE_ESTIMATE:
 		return state.set('feeEstimate', action.estimate)
+	case constants.DOWNLOAD_FILE:
+		return state.set('unreadTransfers', state.get('unreadTransfers') + 1)
+	case constants.UPLOAD_FILE:
+		return state.set('unreadTransfers', state.get('unreadTransfers') + 1)
 	case constants.RECEIVE_FILES:
 		const workingDirectoryFiles = ls(action.files, state.get('path'))
 		const workingDirectorySiapaths = workingDirectoryFiles.map((file) => file.siapath)
@@ -99,6 +104,7 @@ export default function filesReducer(state = initialState, action) {
 		return state.set('showFileTransfers', false)
 	case constants.TOGGLE_FILE_TRANSFERS:
 		return state.set('showFileTransfers', !state.get('showFileTransfers'))
+		            .set('unreadTransfers', 0)
 	case constants.SET_CONTRACT_COUNT:
 		return state.set('contractCount', action.count)
 	case constants.SHOW_RENAME_DIALOG:

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -5,8 +5,7 @@ import fs from 'fs'
 import * as actions from '../actions/files.js'
 import * as constants from '../constants/files.js'
 import { List } from 'immutable'
-import { ls, uploadDirectory, allowancePeriod, allowanceHosts, estimatedStorage, totalSpending, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
-
+import { ls, uploadDirectory, sendError, allowancePeriod, allowanceHosts, estimatedStorage, totalSpending, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
 
 // Query siad for the state of the wallet.
 // dispatch `unlocked` in receiveWalletLockstate

--- a/test/files/files.sagas.js
+++ b/test/files/files.sagas.js
@@ -183,11 +183,11 @@ describe('files plugin sagas', () => {
 		expect(uploadSpy.calledWithExactly('/renter/upload/test/testsiapath/testdir/testfile.app.png')).to.be.true
 	})
 	it('sets uploads on getUploads', async () => {
-		testUploads = [
-			'upload1',
-			'upload2',
-			'upload3',
-		]
+		testUploads = List([
+			{siapath: 'upload1'},
+			{siapath: 'upload2'},
+			{siapath: 'upload3'},
+		])
 		store.dispatch(actions.getUploads())
 		await sleep(10)
 		expect(store.getState().files.get('uploading')).to.deep.equal(testUploads)

--- a/test/files/files.sagas.js
+++ b/test/files/files.sagas.js
@@ -194,14 +194,14 @@ describe('files plugin sagas', () => {
 		expect(SiaAPI.showError.called).to.be.false
 	})
 	it('sets downloads on getDownloads', async () => {
-		testDownloads = [
-			{ name: 'upload4', starttime: new Date() },
-			{ name: 'upload5', starttime: new Date() },
-			{ name: 'upload6', starttime: new Date() },
-		]
+		testDownloads = List([
+			{ siapath: 'upload4', name: 'upload4', starttime: new Date() },
+			{ siapath: 'upload5', name: 'upload5', starttime: new Date() },
+			{ siapath: 'upload6', name: 'upload6', starttime: new Date() },
+		])
 		store.dispatch(actions.getDownloads())
 		await sleep(10)
-		expect(store.getState().files.get('downloading')).to.deep.equal(testDownloads)
+		expect(store.getState().files.get('downloading').toObject()).to.deep.equal(testDownloads.toObject())
 		expect(SiaAPI.showError.called).to.be.false
 	})
 	const testFile = {


### PR DESCRIPTION
This PR adds an animated notification badge that appears after a upload or download on the File Transfers button, in order to notify the user that a download or upload has been initiated. Closes #459

![notify1](https://cloud.githubusercontent.com/assets/8183920/19990255/bfee8e86-a202-11e6-9efb-f0bba7d3f28a.png)
![notify2](https://cloud.githubusercontent.com/assets/8183920/19990254/bfebd484-a202-11e6-973e-0c00b7d6fe81.png)
