### PR TITLE
remove rename, delete, download icons from files: use filecontrols instead

### DIFF
--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -58,7 +58,7 @@ div[tabindex="1"]:focus {
 	position: absolute;
 	bottom: 0;
 	height: 70px;
-	width: 250px;
+	width: 300px;
 	margin-left: auto;
 	margin-right: auto;
 	display: flex;

--- a/plugins/Files/js/components/file.js
+++ b/plugins/Files/js/components/file.js
@@ -1,13 +1,8 @@
 import React, { PropTypes } from 'react'
 import RedundancyStatus from './redundancystatus.js'
 
-
-const File = ({filename, type, selected, filesize, available, redundancy, onDoubleClick, onRenameClick, onDownloadClick, onDeleteClick, onClick}) => (
-	<li
-		onClick={onClick}
-		onDoubleClick={onDoubleClick}
-		className={selected ? 'filebrowser-file selected' : 'filebrowser-file'}
-	>
+const File = ({filename, type, selected, filesize, available, redundancy, onDoubleClick, onClick}) => (
+	<li onClick={onClick} onDoubleClick={onDoubleClick} className={selected ? 'filebrowser-file selected' : 'filebrowser-file'}>
 		<div className="filename">
 			{type === 'file' ? <i className="fa fa-file" /> : <i className="fa fa-folder" onClick={onDoubleClick} />}
 			<div className="name">{filename}</div>
@@ -15,17 +10,6 @@ const File = ({filename, type, selected, filesize, available, redundancy, onDoub
 		<div className="file-info">
 			<span className="filesize">{filesize}</span>
 			<RedundancyStatus available={available} redundancy={redundancy} />
-			<div className="file-buttons">
-				<div onClick={onRenameClick} className="rename-button">
-					<i className="fa fa-pencil 2x" />
-				</div>
-				<div onClick={onDownloadClick} className="download-button">
-					<i className="fa fa-cloud-download 2x" />
-				</div>
-				<div onClick={onDeleteClick} className="delete-button">
-					<i className="fa fa-trash 2x" />
-				</div>
-			</div>
 		</div>
 	</li>
 )
@@ -37,9 +21,6 @@ File.propTypes = {
 	available: PropTypes.bool.isRequired,
 	redundancy: PropTypes.number,
 	selected: PropTypes.bool.isRequired,
-	onRenameClick: PropTypes.func.isRequired,
-	onDownloadClick: PropTypes.func.isRequired,
-	onDeleteClick: PropTypes.func.isRequired,
 	onDoubleClick: PropTypes.func.isRequired,
 	onClick: PropTypes.func.isRequired,
 }

--- a/plugins/Files/js/components/filecontrols.js
+++ b/plugins/Files/js/components/filecontrols.js
@@ -20,12 +20,20 @@ const FileControls = ({files, actions}) => {
 	const onDeleteClick = () => {
 		actions.showDeleteDialog(files)
 	}
+	const onRenameClick = () => {
+		actions.showRenameDialog(files.first())
+	}
 	return (
 		<div className="file-controls">
 			{files.size} {files.size === 1 ? ' item' : ' items' } selected
 			<div onClick={onDownloadClick} className="download-button">
 				<i className="fa fa-cloud-download fa-2x" />
 			</div>
+			{files.size === 1 ? (
+				<div onClick={onRenameClick} className="rename-button">
+					<i className="fa fa-pencil fa-2x" />
+				</div>
+				) : null}
 			<div onClick={onDeleteClick} className="delete-button">
 				<i className="fa fa-trash fa-2x" />
 			</div>

--- a/plugins/Files/js/components/filelist.js
+++ b/plugins/Files/js/components/filelist.js
@@ -25,26 +25,6 @@ const FileList = ({files, selected, searchResults, path, showSearchField, action
 	}
 	const fileElements = filelistFiles.map((file, key) => {
 		const isSelected = selected.map((selectedfile) => selectedfile.name).includes(file.name)
-		const onRenameClick = (e) => {
-			e.stopPropagation()
-			actions.showRenameDialog(file)
-		}
-		const onDownloadClick = (e) => {
-			e.stopPropagation()
-			const downloadpath = SiaAPI.openFile({
-				title: 'Where should we download this file?',
-				properties: ['openDirectory', 'createDirectories'],
-			})
-			if (downloadpath.length === 0) {
-				// No files were selected, nop
-				return
-			}
-			actions.downloadFile(file, Path.join(downloadpath[0], Path.basename(file.siapath)))
-		}
-		const onDeleteClick = (e) => {
-			e.stopPropagation()
-			actions.showDeleteDialog(List([file]))
-		}
 		const onFileClick = (e) => {
 			const shouldMultiSelect = e.ctrlKey || e.metaKey
 			const shouldRangeSelect = e.shiftKey
@@ -76,10 +56,7 @@ const FileList = ({files, selected, searchResults, path, showSearchField, action
 				available={file.available}
 				onDoubleClick={onDoubleClick}
 				type={file.type}
-				onRenameClick={onRenameClick}
 				onClick={onFileClick}
-				onDownloadClick={onDownloadClick}
-				onDeleteClick={onDeleteClick}
 			/>
 		)
 	})

--- a/plugins/Files/js/containers/filecontrols.js
+++ b/plugins/Files/js/containers/filecontrols.js
@@ -1,13 +1,13 @@
 import FileControlsView from '../components/filecontrols.js'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { downloadFile, showDeleteDialog } from '../actions/files.js'
+import { downloadFile, showRenameDialog, showDeleteDialog } from '../actions/files.js'
 
 const mapStateToProps = (state) => ({
 	files: state.files.get('selected'),
 })
 const mapDispatchToProps = (dispatch) => ({
-	actions: bindActionCreators({ downloadFile, showDeleteDialog }, dispatch),
+	actions: bindActionCreators({ downloadFile, showRenameDialog, showDeleteDialog }, dispatch),
 })
 
 const FileControls = connect(mapStateToProps, mapDispatchToProps)(FileControlsView)


### PR DESCRIPTION
This PR removes the rename, delete, and download icons that appear next to every file and instead leverages the existing `FileControls` component to perform that functionality, as discussed in #427.