### PR TITLE
improve directory uploading robustness

### DIFF
--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -5,7 +5,7 @@ import fs from 'fs'
 import * as actions from '../actions/files.js'
 import * as constants from '../constants/files.js'
 import { List } from 'immutable'
-import { ls, allowancePeriod, allowanceHosts, estimatedStorage, totalSpending, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
+import { ls, uploadDirectory, allowancePeriod, allowanceHosts, estimatedStorage, totalSpending, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
 
 
 // Query siad for the state of the wallet.
@@ -112,15 +112,13 @@ function* uploadFileSaga(action) {
 	}
 }
 
-// Recursively upload the folder at the directory `source`
+// uploadFolderSaga uploads a folder to the Sia network.
+// action.source: the source path of the folder
+// action.siapath: the working directory to upload the folder inside
 function *uploadFolderSaga(action) {
 	try {
 		const files = readdirRecursive(action.source)
-		const folderName = Path.basename(action.source)
-		const uploads = files.map((file) => ({
-			siapath: Path.posix.join(action.siapath, file.substring(file.indexOf(folderName), file.lastIndexOf(Path.basename(file))).replace(new RegExp('\\' + Path.win32.sep, 'g'), '/')),
-			source: file,
-		})).map((file) => actions.uploadFile(file.siapath, file.source))
+		const uploads = uploadDirectory(action.source, files, action.siapath)
 		for (const upload in uploads.toArray()) {
 			yield put(uploads.get(upload))
 		}

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -130,9 +130,9 @@ export const readdirRecursive = (path, files) => {
 	return filelist
 }
 
-// uploadDirectory takes a `source` and a `siapath` and returns a list of
-// upload actions that will upload every file located under `source`/ to
-// `siapath`/.
+// uploadDirectory takes a `directory`, a list of files inside the directory,
+// and a destination siapath and returns a List of upload actions that will
+// upload each file to `destpath/directoryname/`.
 export const uploadDirectory = (directory, files, destpath) => {
 	const uploads = files.map((file) => {
 		const siapath = Path.dirname(file.substring(directory.length + 1))

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -133,16 +133,15 @@ export const readdirRecursive = (path, files) => {
 // uploadDirectory takes a `directory`, a list of files inside the directory,
 // and a destination siapath and returns a List of upload actions that will
 // upload each file to `destpath/directoryname/`.
-export const uploadDirectory = (directory, files, destpath) => {
-	const uploads = files.map((file) => {
-		const siapath = Path.dirname(file.substring(directory.length + 1))
+export const uploadDirectory = (directory, files, destpath) =>
+	files.map((file) => {
+		const relativePath = Path.dirname(file.substring(directory.length + 1))
+		const siapath = Path.posix.join(destpath, Path.basename(directory), relativePath)
 		return {
 			source: file,
-			siapath: Path.posix.join(destpath, Path.basename(directory), siapath),
+			siapath,
 		}
-	})
-	return uploads.map((upload) => actions.uploadFile(upload.siapath, upload.source))
-}
+	}).map((upload) => actions.uploadFile(upload.siapath, upload.source))
 
 // avgHostMetric computes the average of the metric given by `metric` on the
 // list of `hosts`.

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -137,11 +137,8 @@ export const uploadDirectory = (directory, files, destpath) =>
 	files.map((file) => {
 		const relativePath = Path.dirname(file.substring(directory.length + 1))
 		const siapath = Path.posix.join(destpath, Path.basename(directory), relativePath)
-		return {
-			source: file,
-			siapath,
-		}
-	}).map((upload) => actions.uploadFile(upload.siapath, upload.source))
+		return actions.uploadFile(siapath, file)
+	})
 
 // avgHostMetric computes the average of the metric given by `metric` on the
 // list of `hosts`.

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -3,6 +3,7 @@ import { List, Map } from 'immutable'
 import BigNumber from 'bignumber.js'
 import Path from 'path'
 import fs from 'fs'
+import * as actions from '../actions/files.js'
 
 export const blockMonth = 4320
 export const allowanceMonths = 3
@@ -127,6 +128,20 @@ export const readdirRecursive = (path, files) => {
 		}
 	})
 	return filelist
+}
+
+// uploadDirectory takes a `source` and a `siapath` and returns a list of
+// upload actions that will upload every file located under `source`/ to
+// `siapath`/.
+export const uploadDirectory = (directory, files, destpath) => {
+	const uploads = files.map((file) => {
+		const siapath = Path.dirname(file.substring(directory.length + 1))
+		return {
+			source: file,
+			siapath: Path.posix.join(destpath, Path.basename(directory), siapath),
+		}
+	})
+	return uploads.map((upload) => actions.uploadFile(upload.siapath, upload.source))
 }
 
 // avgHostMetric computes the average of the metric given by `metric` on the

--- a/test/files/files.sagas.js
+++ b/test/files/files.sagas.js
@@ -166,21 +166,21 @@ describe('files plugin sagas', () => {
 	it('calls /renter/upload correctly on every file in a folder on uploadFolder', async () => {
 		uploadSpy.reset()
 		testDirectoryFiles = List([
-			'testfile5',
-			'testfile6',
-			'testfolder/testfile2.jpg',
-			'testfolder/testfolder2/testfolder.png',
-			'testfile.app.png',
+			'/test/testdir/testfile5',
+			'/test/testdir/testfile6',
+			'/test/testdir/testfolder/testfile2.jpg',
+			'/test/testdir/testfolder/testfolder2/testfolder.png',
+			'/test/testdir/testfile.app.png',
 		])
 		store.dispatch(actions.uploadFolder('test/testsiapath', '/test/testdir'))
 		await sleep(10)
 		expect(SiaAPI.showError.called).to.be.false
 		expect(uploadSpy.callCount).to.equal(testDirectoryFiles.size)
-		let callIndex = 0
-		testDirectoryFiles.forEach((file) => {
-			expect(uploadSpy.getCall(callIndex).calledWithExactly('/renter/upload/test/testsiapath/' + file)).to.be.true
-			callIndex++
-		})
+		expect(uploadSpy.calledWithExactly('/renter/upload/test/testsiapath/testdir/testfile5')).to.be.true
+		expect(uploadSpy.calledWithExactly('/renter/upload/test/testsiapath/testdir/testfile6')).to.be.true
+		expect(uploadSpy.calledWithExactly('/renter/upload/test/testsiapath/testdir/testfolder/testfile2.jpg')).to.be.true
+		expect(uploadSpy.calledWithExactly('/renter/upload/test/testsiapath/testdir/testfolder/testfolder2/testfolder.png')).to.be.true
+		expect(uploadSpy.calledWithExactly('/renter/upload/test/testsiapath/testdir/testfile.app.png')).to.be.true
 	})
 	it('sets uploads on getUploads', async () => {
 		testUploads = [

--- a/test/files/helpers.js
+++ b/test/files/helpers.js
@@ -104,6 +104,9 @@ describe('files plugin helper functions', () => {
 		})
 	})
 	it('should ls a file list correctly', () => {
+		const lsWin32 = proxyquire('../../plugins/Files/js/sagas/helpers.js', {
+			'path': Path.win32,
+		}).ls
 		const siapathInputs = List([
 			{ filesize: 1337, siapath: 'folder/file.jpg', redundancy: 2.0, available: true, uploadprogress: 100 },
 			{ filesize: 13117, siapath: 'folder/file2.jpg', redundancy: 2.0, available: true, uploadprogress: 100 },
@@ -135,6 +138,8 @@ describe('files plugin helper functions', () => {
 		}
 		for (const path in expectedOutputs) {
 			const output = ls(siapathInputs, path)
+			const outputWin32 = lsWin32(siapathInputs, path)
+			expect(output).to.deep.equal(outputWin32)
 			expect(output.size).to.equal(expectedOutputs[path].size)
 			expect(output.toObject()).to.deep.equal(expectedOutputs[path].toObject())
 		}


### PR DESCRIPTION
This PR adds `uploadDirectory`, a helper function to make folder upload action generation more testable and robust. Both win32 and posix upload testing has been added.