### PR TITLE
add production webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "scripts": {
     "start": "webpack && electron .",
     "debug": "webpack -d && electron .",
+    "build-production": "webpack -p --config ./webpack.production.config.js",
     "build": "webpack",
     "watch": "webpack --watch",
     "clean": "rm -rf release doc/Sia-UI node_modules Sia config.json **/*.swp npm-debug.log",

--- a/release.sh
+++ b/release.sh
@@ -14,7 +14,8 @@ if [[ -z $1 || -z $2 ]]; then
 	exit 1
 fi
 
-npm run build
+rm -rf ./dist
+npm run build-production
 
 uiVersion=${3:-v1.0.2}
 siaVersion=${4:-v1.0.1}

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const glob = require('glob')
+const webpack = require('webpack')
 
 // Compute the entry-points for Sia-UI.
 let entrypoints = {}
@@ -17,6 +18,13 @@ entrypoints["pluginapi"] = ['babel-polyfill', path.resolve('./js/rendererjs/plug
 
 module.exports = {
 	entry: entrypoints,
+	plugins: [
+		new webpack.DefinePlugin({
+			"process.env": {
+				NODE_ENV: JSON.stringify("production")
+			}
+		})
+	],
 	output: {
 		path: path.resolve("./dist"),
 		filename: '[name].js'


### PR DESCRIPTION
This PR adds `build-production`, and a `webpack.production.config.js` that uses the `webpack -p` flag, minifying and deduplicating the built JS.