### PR TITLE
use expanding buffers to buffer download/delete/upload actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^15.0.2",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
-    "redux-saga": "^0.11.0",
+    "redux-saga": "^0.13.0",
     "sia.js": "^0.3.3",
     "webpack": "^1.13.1"
   },

--- a/plugins/Files/js/components/filecontrols.js
+++ b/plugins/Files/js/components/filecontrols.js
@@ -18,7 +18,7 @@ const FileControls = ({files, actions}) => {
 		})
 	}
 	const onDeleteClick = () => {
-		actions.showDeleteDialog(files)
+		actions.showDeleteDialog(files.toList())
 	}
 	const onRenameClick = () => {
 		actions.showRenameDialog(files.first())

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -1,4 +1,4 @@
-import { takeEvery } from 'redux-saga'
+import { takeEvery, buffers } from 'redux-saga'
 import { put, actionChannel, take } from 'redux-saga/effects'
 import Path from 'path'
 import fs from 'fs'
@@ -256,7 +256,7 @@ export function* watchGetFiles() {
 	yield *takeEvery(constants.GET_FILES, getFilesSaga)
 }
 export function* watchDeleteFile() {
-	const deleteChan = yield actionChannel(constants.DELETE_FILE)
+	const deleteChan = yield actionChannel(constants.DELETE_FILE, buffers.expanding(24))
 	while (true) {
 		const deleteAction = yield take(deleteChan)
 		yield *deleteFileSaga(deleteAction)
@@ -272,7 +272,7 @@ export function* watchGetContractCount() {
 	yield *takeEvery(constants.GET_CONTRACT_COUNT, getContractCountSaga)
 }
 export function* watchUploadFile() {
-	const uploadChan = yield actionChannel(constants.UPLOAD_FILE)
+	const uploadChan = yield actionChannel(constants.UPLOAD_FILE, buffers.expanding(24))
 	while (true) {
 		const uploadAction = yield take(uploadChan)
 		yield *uploadFileSaga(uploadAction)
@@ -282,7 +282,7 @@ export function* watchDownloadFile() {
 	yield *takeEvery(constants.DOWNLOAD_FILE, downloadFileSaga)
 }
 export function* watchRenameFile() {
-	const renameChan = yield actionChannel(constants.RENAME_FILE)
+	const renameChan = yield actionChannel(constants.RENAME_FILE, buffers.expanding(24))
 	while (true) {
 		const renameAction = yield take(renameChan)
 		yield *renameFileSaga(renameAction)

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -63,13 +63,17 @@ export const readableFilesize = (bytes) => {
 
 // minRedundancy takes a list of files and returns the minimum redundancy that
 // occurs in the list.
-export const minRedundancy = (files) =>
-	files.min((a, b) => {
+export const minRedundancy = (files) => {
+	if (files.size === 0) {
+		return 0
+	}
+	return files.min((a, b) => {
 		if (a.redundancy > b.redundancy) {
 			return 1
 		}
 		return -1
 	}).redundancy
+}
 
 // return a list of files filtered with path.
 // ... it's ls.

--- a/test/files/files.sagas.js
+++ b/test/files/files.sagas.js
@@ -208,6 +208,24 @@ describe('files plugin sagas', () => {
 		siapath: 'test/siapath',
 		type: 'file',
 	}
+	it('can buffer lots of delete actions', () => {
+		for (let i = 0; i < 4096; i++) {
+			store.dispatch(actions.deleteFile(testFile))
+		}
+		expect(SiaAPI.showError.called).to.be.false
+	})
+	it('can buffer lots of upload actions', () => {
+		for (let i = 0; i < 4096; i++) {
+			store.dispatch(actions.uploadFile('testfile', ''))
+		}
+		expect(SiaAPI.showError.called).to.be.false
+	})
+	it('can buffer lots of download actions', () => {
+		for (let i = 0; i < 4096; i++) {
+			store.dispatch(actions.downloadFile('testfile', ''))
+		}
+		expect(SiaAPI.showError.called).to.be.false
+	})
 	it('calls /renter/download on downloadFile', async () => {
 		store.dispatch(actions.downloadFile(testFile, '/test/downloadpath'))
 		await sleep(10)

--- a/test/files/helpers.js
+++ b/test/files/helpers.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { uploadDirectory, rangeSelect, readableFilesize, ls } from '../../plugins/Files/js/sagas/helpers.js'
+import { minRedundancy, uploadDirectory, rangeSelect, readableFilesize, ls } from '../../plugins/Files/js/sagas/helpers.js'
 import { List, OrderedSet } from 'immutable'
 import proxyquire from 'proxyquire'
 import Path from 'path'
@@ -177,5 +177,13 @@ describe('files plugin helper functions', () => {
 			expect(output.size).to.equal(expectedOutputs[path].size)
 			expect(output.toObject()).to.deep.equal(expectedOutputs[path].toObject())
 		}
+	})
+	describe('minRedundancy', () => {
+		it('returns correct values for list of size 0', () => {
+			expect(minRedundancy(List())).to.equal(0)
+		})
+		it('returns correct values given a list of files', () => {
+			expect(minRedundancy(List([{redundancy: 0.5}, {redundancy: 1.2}, {redundancy: 1.3}, {redundancy: 0.2}]))).to.equal(0.2)
+		})
 	})
 })


### PR DESCRIPTION
by default, `redux-saga`'s actionChannel uses a fixed buffer size of 10. When uploading, downloading, or deleting large arrays of files this buffer size is too small, as reported in slack. This PR changes our actionChannels to use an expanding buffer, with an initial size of 24. This also fixes a bug in `minRedundancy`.