### PR TITLE
move the file transfers close button further from the scroll bar

### DIFF
--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -267,8 +267,8 @@ div[tabindex="1"]:focus {
 }
 .file-transfers .close-button {
 	position: absolute;
-	top: 0;
-	right: 10px;
+	top: 2px;
+	right: 16px;
 	cursor: pointer;
 }
 .file-list h2 {


### PR DESCRIPTION
This pr moves the close button for the file transfers view further to the left so that it does not overlap with scroll bars.