### PR TITLE
use graceful-fs in Logs plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-stage-3": "^6.5.0",
     "bignumber.js": "^2.1.3",
     "electron": "^1.3.2",
+    "graceful-fs": "^4.1.11",
     "immutable": "^3.8.1",
     "json-loader": "^0.5.4",
     "mkdirp": "^0.5.1",

--- a/plugins/Logs/js/logparse.js
+++ b/plugins/Logs/js/logparse.js
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'graceful-fs'
 import { readdirRecursive } from './utils.js'
 
 const siadir = SiaAPI.config.siad.datadir


### PR DESCRIPTION
this PR changes the Logs plugin to use [graceful-fs](https://github.com/isaacs/node-graceful-fs), making the plugin more resilient to filesystem errors. The graceful-fs docs provide a good overview of all the improvements. In our case, opening many logs at once caused some `EMFile` errors under certain circumstances, which graceful-fs is designed to fix:

```
The goal is to trade EMFILE errors for slower fs operations. So, if you try to open a zillion files, rather than crashing, open operations will be queued up and wait for something else to close.
```

There are likely other places in Sia-UI where we desire this same behavior.