### PR TITLE
fix shift click not deselecting log filters

### DIFF
--- a/plugins/Logs/js/components/filtercontrol.js
+++ b/plugins/Logs/js/components/filtercontrol.js
@@ -12,19 +12,19 @@ const FilterControl = ({ name, filters, checked, addLogFilters, removeLogFilters
 		cursor: 'pointer',
 		borderBottom: checked ? '4px solid #00CBA0' : '1px solid #00CBA0',
 	}
-	const onFilterClick = (clickedFilters) => (e) => {
+	const onFilterClick = (e) => {
 		if (!e.shiftKey && !e.ctrlKey) {
-			setLogFilters(clickedFilters)
+			setLogFilters(filters)
 			return
 		}
-		if (checked && filters.size > 1) {
-			removeLogFilters(clickedFilters)
+		if (checked) {
+			removeLogFilters(filters)
 			return
 		}
-		addLogFilters(clickedFilters)
+		addLogFilters(filters)
 	}
 	return (
-		<div style={filterControlStyle} onClick={onFilterClick(filters)}>
+		<div style={filterControlStyle} onClick={onFilterClick}>
 			<span style={{WebkitUserSelect: 'none'}}> {name} </span>
 		</div>
 	)

--- a/plugins/Logs/js/logparse.js
+++ b/plugins/Logs/js/logparse.js
@@ -49,6 +49,12 @@ export const addLogFilters = (state, filters) =>
 	updateLogFilters(state, state.get('logSize'), state.get('logFilters').union(filters))
 
 // removeLogFilters removes an array of filters.
-export const removeLogFilters = (state, filters) =>
-	updateLogFilters(state, state.get('logSize'), state.get('logFilters').subtract(filters))
+export const removeLogFilters = (state, filters) => {
+	// no-op if remnoval results in no filters
+	const newFilters = state.get('logFilters').subtract(filters)
+	if (newFilters.size === 0) {
+		return state
+	}
+	return updateLogFilters(state, state.get('logSize'), newFilters)
+}
 

--- a/test/logs/logs.integration.js
+++ b/test/logs/logs.integration.js
@@ -48,4 +48,16 @@ describe('logs plugin', () => {
 			expect(rootComponent.find('LogView').props().logText).to.equal(parseLogs(siadir, 50000, filterFilters))
 		}
 	})
+	it('deselects filter controls when selected and shift-clicked', async () => {
+		const filterControlNodes = rootComponent.find('FilterControl')
+		filterControlNodes.at(0).simulate('click')
+		await sleep(50)
+		filterControlNodes.at(1).simulate('click', { shiftKey: true })
+		await sleep(50)
+		filterControlNodes.at(1).simulate('click', { shiftKey: true })
+		await sleep(50)
+		const expectedFilters = filters.filter((f) => f.name === filterControlNodes.at(0).props().name)[0].filters
+		expect(filterControlNodes.at(1).props().checked).to.equal(false)
+		expect(rootComponent.find('LogView').props().logText).to.equal(parseLogs(siadir, 50000, expectedFilters))
+	})
 })


### PR DESCRIPTION
This PR fixes a bug that caused log filters not to be deselected when selected and shift-clicked.