### PR TITLE
compile the plugin api into each plugin instead of using `preload`

### DIFF
--- a/js/rendererjs/plugins.js
+++ b/js/rendererjs/plugins.js
@@ -23,7 +23,6 @@ const createButtonTextElement = (name) => {
 }
 
 // Construct a plugin view element from a plugin path and title
-// use webview.preload to inject SiaAPI into the plugin's global namespace.
 const createPluginElement = (markupPath, title) => {
 	const elem = document.createElement('webview')
 	elem.id = title + '-view'
@@ -31,7 +30,6 @@ const createPluginElement = (markupPath, title) => {
 	elem.src = markupPath
 	// This is enabled for legacy plugin support.
 	elem.nodeintegration = true
-	elem.preload = './dist/pluginapi.js'
 	return elem
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const glob = require('glob')
 let entrypoints = {}
 const plugins = glob.sync("./plugins/*/js/index.js")
 plugins.forEach((plugin) => {
-	entrypoints[path.dirname(path.dirname(plugin))] = ['babel-polyfill', './js/rendererjs/pluginapi.js', plugin]
+	entrypoints[path.dirname(path.dirname(plugin))] = ['babel-polyfill', path.resolve('./js/rendererjs/pluginapi.js'), plugin]
 })
 
 entrypoints["renderer"] = ['babel-polyfill', path.resolve('./js/rendererjs/index.js')]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,13 +7,11 @@ const glob = require('glob')
 let entrypoints = {}
 const plugins = glob.sync("./plugins/*/js/index.js")
 plugins.forEach((plugin) => {
-	entrypoints[path.dirname(path.dirname(plugin))] = plugin
+	entrypoints[path.dirname(path.dirname(plugin))] = ['babel-polyfill', './js/rendererjs/pluginapi.js', plugin]
 })
 
 entrypoints["renderer"] = ['babel-polyfill', path.resolve('./js/rendererjs/index.js')]
 entrypoints["main"] = path.resolve('./js/mainjs/index.js')
-entrypoints["pluginapi"] = ['babel-polyfill', path.resolve('./js/rendererjs/pluginapi.js')]
-
 
 module.exports = {
 	entry: entrypoints,

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -8,7 +8,7 @@ const webpack = require('webpack')
 let entrypoints = {}
 const plugins = glob.sync("./plugins/*/js/index.js")
 plugins.forEach((plugin) => {
-	entrypoints[path.dirname(path.dirname(plugin))] = ['babel-polyfill', './js/rendererjs/pluginapi.js', plugin]
+	entrypoints[path.dirname(path.dirname(plugin))] = ['babel-polyfill', path.resolve('./js/rendererjs/pluginapi.js'), plugin]
 })
 
 entrypoints["renderer"] = ['babel-polyfill', path.resolve('./js/rendererjs/index.js')]

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -8,12 +8,11 @@ const webpack = require('webpack')
 let entrypoints = {}
 const plugins = glob.sync("./plugins/*/js/index.js")
 plugins.forEach((plugin) => {
-	entrypoints[path.dirname(path.dirname(plugin))] = plugin
+	entrypoints[path.dirname(path.dirname(plugin))] = ['babel-polyfill', './js/rendererjs/pluginapi.js', plugin]
 })
 
 entrypoints["renderer"] = ['babel-polyfill', path.resolve('./js/rendererjs/index.js')]
 entrypoints["main"] = path.resolve('./js/mainjs/index.js')
-entrypoints["pluginapi"] = ['babel-polyfill', path.resolve('./js/rendererjs/pluginapi.js')]
 
 
 module.exports = {


### PR DESCRIPTION
This PR fixes nondeterminism in the build system, where plugins could under certain circumstances on certain systems load before the plugin api, causing a 'white screen' crash. The plugin api is now compiled into each plugin using `webpack`, instead of preloaded.