### PR TITLE
properly parse negative redundancy values

### DIFF
--- a/plugins/Files/js/components/redundancystatus.js
+++ b/plugins/Files/js/components/redundancystatus.js
@@ -22,7 +22,7 @@ const RedundancyStatus = ({available, redundancy}) => {
 	return (
 		<div className="redundancy-status">
 			<i className="fa fa-cubes" style={indicatorStyle} />
-			<span className="redundancy-text">{redundancy}x</span>
+			<span className="redundancy-text">{redundancy > 0 ? redundancy + 'x' : '--'}</span>
 		</div>
 	)
 }

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -74,7 +74,7 @@ export const minRedundancy = (files) => {
 		return -1
 	}
 
-	// ignore files that have negative redundancy
+	// return the minimum redundancy of all the files with redundancy >= 0
 	return redundantFiles.min((a, b) => {
 		if (a.redundancy > b.redundancy) {
 			return 1

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -67,7 +67,15 @@ export const minRedundancy = (files) => {
 	if (files.size === 0) {
 		return 0
 	}
-	return files.min((a, b) => {
+	const redundantFiles = files.filter((file) => file.redundancy >= 0)
+
+	// if all the provided files have -1 redundancy, return -1.
+	if (redundantFiles.size === 0) {
+		return -1
+	}
+
+	// ignore files that have negative redundancy
+	return redundantFiles.min((a, b) => {
 		if (a.redundancy > b.redundancy) {
 			return 1
 		}

--- a/test/files/filelist.component.js
+++ b/test/files/filelist.component.js
@@ -10,6 +10,7 @@ const testFiles = List([
 	{size: '', name: 'movies', type: 'directory'},
 	{size: '137mb', available: true, redundancy: 1.5, name: 'test.jpg', siapath: 'test.jpg', type: 'file'},
 	{size: '137mb', available: true, redundancy: 2.0, name: 'meme.avi', siapath: 'meme.avi', type: 'file'},
+	{size: '137mb', available: true, redundancy: -1, name: 'test-0bytes', siapath: 'test-0bytes', type: 'file'},
 	{size: '', name: 'dankpepes', type: 'directory'},
 ])
 

--- a/test/files/helpers.js
+++ b/test/files/helpers.js
@@ -149,6 +149,7 @@ describe('files plugin helper functions', () => {
 			{ filesize: 1337, siapath: 'memes/itsdatboi.mov', redundancy: 2.0, available: true, uploadprogress: 100 },
 			{ filesize: 1337, siapath: 'memes/rares/lordkek.gif', redundancy: 1.6, available: true, uploadprogress: 100 },
 			{ filesize: 13117, siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 100 },
+			{ filesize: 13117, siapath: 'test_0bytes.avi', redundancy: -1, available: true, uploadprogress: 100 },
 			{ filesize: 1331, siapath: 'doggos/borkborkdoggo.png', redundancy: 1.5, available: true, uploadprogress: 100 },
 			{ filesize: 1333, siapath: 'doggos/snip_snip_doggo_not_bork_bork_kind.jpg', redundancy: 1.0, available: true, uploadprogress: 100 },
 		])
@@ -159,6 +160,7 @@ describe('files plugin helper functions', () => {
 				{ size: readableFilesize(1317+1337+1337), name: 'memes', siapath: 'memes/', redundancy: 1.6, available: true, uploadprogress: 100, type: 'directory' },
 				{ size: readableFilesize(1237), name: 'rare_pepe.png', siapath: 'rare_pepe.png', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
 				{ size: readableFilesize(13117), name: 'sibyl_system.avi', siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 100, type: 'file' },
+				{ size: readableFilesize(13117), name: 'test_0bytes.avi', siapath: 'test_0bytes.avi' ,redundancy: -1.0, available: true, uploadprogress: 100, type: 'file'},
 			]),
 			'doggos/': List([
 				{ size: readableFilesize(1331), name: 'borkborkdoggo.png', siapath: 'doggos/borkborkdoggo.png', redundancy: 1.5, available: true, uploadprogress: 100, type: 'file' },
@@ -184,6 +186,12 @@ describe('files plugin helper functions', () => {
 		})
 		it('returns correct values given a list of files', () => {
 			expect(minRedundancy(List([{redundancy: 0.5}, {redundancy: 1.2}, {redundancy: 1.3}, {redundancy: 0.2}]))).to.equal(0.2)
+		})
+		it('ignores negative redundancy values', () => {
+			expect(minRedundancy(List([{redundancy: -1}, {redundancy: 1.5}, {redundancy: 1.1}]))).to.equal(1.1)	
+		})
+		it('returns correct values for a list of only negative redundancy', () => {
+			expect(minRedundancy(List([{redundancy: -1}, {redundancy: -1}]))).to.equal(-1)
 		})
 	})
 })

--- a/test/files/helpers.js
+++ b/test/files/helpers.js
@@ -160,7 +160,7 @@ describe('files plugin helper functions', () => {
 				{ size: readableFilesize(1317+1337+1337), name: 'memes', siapath: 'memes/', redundancy: 1.6, available: true, uploadprogress: 100, type: 'directory' },
 				{ size: readableFilesize(1237), name: 'rare_pepe.png', siapath: 'rare_pepe.png', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
 				{ size: readableFilesize(13117), name: 'sibyl_system.avi', siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 100, type: 'file' },
-				{ size: readableFilesize(13117), name: 'test_0bytes.avi', siapath: 'test_0bytes.avi' ,redundancy: -1.0, available: true, uploadprogress: 100, type: 'file'},
+				{ size: readableFilesize(13117), name: 'test_0bytes.avi', siapath: 'test_0bytes.avi', redundancy: -1.0, available: true, uploadprogress: 100, type: 'file'},
 			]),
 			'doggos/': List([
 				{ size: readableFilesize(1331), name: 'borkborkdoggo.png', siapath: 'doggos/borkborkdoggo.png', redundancy: 1.5, available: true, uploadprogress: 100, type: 'file' },
@@ -188,7 +188,7 @@ describe('files plugin helper functions', () => {
 			expect(minRedundancy(List([{redundancy: 0.5}, {redundancy: 1.2}, {redundancy: 1.3}, {redundancy: 0.2}]))).to.equal(0.2)
 		})
 		it('ignores negative redundancy values', () => {
-			expect(minRedundancy(List([{redundancy: -1}, {redundancy: 1.5}, {redundancy: 1.1}]))).to.equal(1.1)	
+			expect(minRedundancy(List([{redundancy: -1}, {redundancy: 1.5}, {redundancy: 1.1}]))).to.equal(1.1)
 		})
 		it('returns correct values for a list of only negative redundancy', () => {
 			expect(minRedundancy(List([{redundancy: -1}, {redundancy: -1}]))).to.equal(-1)


### PR DESCRIPTION
This PR updates `minRedundancy` to ignore negative redundancy values when computing the minimum redundancy of a directory, and changes the `RedundancyStatus` component to display `--` for files with negative redundancy (most commonly 0-byte files.)