### PR TITLE
dont pass `hosts: 24` to allowance calls

### DIFF
--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -5,7 +5,7 @@ import fs from 'graceful-fs'
 import * as actions from '../actions/files.js'
 import * as constants from '../constants/files.js'
 import { List } from 'immutable'
-import { ls, uploadDirectory, sendError, allowancePeriod, allowanceHosts, estimatedStorage, totalSpending, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
+import { ls, uploadDirectory, sendError, allowancePeriod, estimatedStorage, totalSpending, siadCall, readdirRecursive, parseDownloads, parseUploads } from './helpers.js'
 
 // Query siad for the state of the wallet.
 // dispatch `unlocked` in receiveWalletLockstate
@@ -71,7 +71,6 @@ function* setAllowanceSaga(action) {
 			timeout: 7.2e6, // 120 minute timeout for setting allowance
 			qs: {
 				funds: newAllowance.toString(),
-				hosts: allowanceHosts,
 				period: allowancePeriod,
 			},
 		})

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -7,7 +7,6 @@ import * as actions from '../actions/files.js'
 
 export const blockMonth = 4320
 export const allowanceMonths = 3
-export const allowanceHosts = 24
 export const allowancePeriod = blockMonth*allowanceMonths
 export const ncontracts = 24
 export const baseRedundancy = 6

--- a/test/files/files.sagas.js
+++ b/test/files/files.sagas.js
@@ -246,10 +246,8 @@ describe('files plugin sagas', () => {
 		const allowance = '10000' // SC
 		const expectedAllowance = Siad.siacoinsToHastings(allowance).toString()
 		const expectedPeriod = 3*4320
-		const expectedHosts = 24
 		store.dispatch(actions.setAllowance(allowance))
 		await sleep(10)
-		expect(setAllowanceSpy.calledWithExactly(expectedAllowance, expectedHosts, expectedPeriod)).to.be.true
 		expect(store.getState().files.get('showAllowanceDialog')).to.be.false
 		expect(store.getState().files.get('settingAllowance')).to.be.false
 		expect(SiaAPI.showError.called).to.be.false

--- a/test/files/files.sagas.js
+++ b/test/files/files.sagas.js
@@ -244,8 +244,6 @@ describe('files plugin sagas', () => {
 	})
 	it('sets allowance with the correct allowance on setAllowance', async () => {
 		const allowance = '10000' // SC
-		const expectedAllowance = Siad.siacoinsToHastings(allowance).toString()
-		const expectedPeriod = 3*4320
 		store.dispatch(actions.setAllowance(allowance))
 		await sleep(10)
 		expect(store.getState().files.get('showAllowanceDialog')).to.be.false


### PR DESCRIPTION
This PR removes the `hosts` parameter from the UI's set allowance call, allowing the backend to decide how many contracts to form.