### PR TITLE
filter out uploads with <0 redundancy from uploads

### DIFF
--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -207,6 +207,7 @@ export const totalUsage = (files) => readableFilesize(files.reduce((sum, file) =
 // return a list of file uploads
 export const parseUploads = (files) =>
 	List(files)
+		.filter((file) => file.redundancy >= 0)
 		.filter((file) => file.redundancy < 2.5)
 		.filter((file) => file.uploadprogress < 100)
 		.map((upload) => ({


### PR DESCRIPTION
This PR prevents files with -1 redundancy from being shown in the upload list.