### PR TITLE
build plugin api into about plugin, VERSION into bundle

### DIFF
--- a/plugins/About/index.html
+++ b/plugins/About/index.html
@@ -33,6 +33,6 @@
 		</div>
 		
 		<!-- JS -->
-		<script src="js/about.js"></script>
+		<script src="../../dist/plugins/About.js"></script>
 	</body>
 </html>

--- a/plugins/About/js/index.js
+++ b/plugins/About/js/index.js
@@ -1,8 +1,5 @@
 'use strict'
 
-// Library for communicating with Sia-UI
-const electron = require('electron')
-
 // Set UI version via package.json.
 document.getElementById('uiversion').innerHTML = VERSION
 

--- a/plugins/About/js/index.js
+++ b/plugins/About/js/index.js
@@ -4,7 +4,7 @@
 const electron = require('electron')
 
 // Set UI version via package.json.
-document.getElementById('uiversion').innerHTML = require('../../package.json').version
+document.getElementById('uiversion').innerHTML = VERSION
 
 // Set daemon version via API call.
 SiaAPI.call('/daemon/version', (err, result) => {
@@ -16,7 +16,3 @@ SiaAPI.call('/daemon/version', (err, result) => {
 	}
 })
 
-// Make FAQ button launch the FAQ webpage.
-document.getElementById('faq').onclick = function() {
-	electron.shell.openExternal('http://sia.tech/faq')
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const webpack = require('webpack')
 const path = require('path')
 const glob = require('glob')
 
@@ -15,6 +16,11 @@ entrypoints["main"] = path.resolve('./js/mainjs/index.js')
 
 module.exports = {
 	entry: entrypoints,
+	plugins: [
+		new webpack.DefinePlugin({
+			VERSION: JSON.stringify(require("./package.json").version)
+		})
+	],
 	output: {
 		path: path.resolve("./dist"),
 		filename: '[name].js'

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -22,6 +22,9 @@ module.exports = {
 			"process.env": {
 				NODE_ENV: JSON.stringify("production")
 			}
+		}),
+		new webpack.DefinePlugin({
+			VERSION: JSON.stringify(require("./package.json").version)
 		})
 	],
 	output: {


### PR DESCRIPTION
This PR compiles the plugin API into the about plugin, since it's required for making API calls. It also adds a `VERSION` global to the bundle, so plugins know what version of Sia-UI is running.