### PR TITLE
properly make Sia-UI single instance

### DIFF
--- a/js/mainjs/index.js
+++ b/js/mainjs/index.js
@@ -7,16 +7,24 @@ import initWindow from './initWindow.js'
 global.config = loadConfig(Path.join(__dirname, '../config.json'))
 let mainWindow
 
+// Allow only one instance of Sia-UI
+const shouldQuit = app.makeSingleInstance(() => {
+	if (mainWindow) {
+		if (mainWindow.isMinimized()) {
+			mainWindow.restore()
+		}
+		mainWindow.focus()
+	}
+})
+
+if (shouldQuit) {
+	app.quit()
+}
+
 // When Electron loading has finished, start Sia-UI.
 app.on('ready', () => {
 	// Load mainWindow
 	mainWindow = initWindow(config)
-})
-
-// Allow only one instance of Sia-UI
-app.makeSingleInstance(() => {
-	mainWindow.restore()
-	mainWindow.focus()
 })
 
 // Quit once all windows have been closed.


### PR DESCRIPTION
This PR utilizes `app.makeSingleInstance` properly, using its return value (bool) to prevent any extra instances of Sia-UI from running while an instance is already open. When a new instance is started, the original instance is restored and focused and the new instance is quit.

Fixes #496 