### PR TITLE
dont remove uploads once they exceed 2.5x redundancy

### DIFF
--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -195,7 +195,6 @@ export const totalUsage = (files) => readableFilesize(files.reduce((sum, file) =
 export const parseUploads = (files) =>
 	List(files)
 		.filter((file) => file.redundancy >= 0)
-		.filter((file) => file.redundancy < 2.5)
 		.filter((file) => file.uploadprogress < 100)
 		.map((upload) => ({
 			status: (() => {


### PR DESCRIPTION
Now that uploads progress to 100%, they should stay in the transfer list until they reach completion, reflecting their exact progress.