### PR TITLE
clear blur/focus event listeners when a new plugin is selected

### DIFF
--- a/js/rendererjs/plugins.js
+++ b/js/rendererjs/plugins.js
@@ -63,6 +63,8 @@ export const setCurrentPlugin = (pluginName) => {
 		buttonElem.classList.add('current')
 	}
 	remote.globalShortcut.unregister(devtoolsShortcut)
+	remote.app.removeAllListeners('browser-window-blur')
+	remote.app.removeAllListeners('browser-window-focus')
 	registerLocalShortcut(devtoolsShortcut, () => {
 		viewElem.openDevTools()
 	})


### PR DESCRIPTION
the new local shortcut code registers a `browser-window-blur` and `browser-window-focus` event every time a new plugin is selected, but does not clear the previous event listeners, leading to an eventemitter leak. This PR fixes that issue.