### PR TITLE
add a few missing props to files tests

### DIFF
--- a/test/files/filebrowser.component.js
+++ b/test/files/filebrowser.component.js
@@ -14,7 +14,7 @@ const testDrag = (files) => {
 		showUploadDialog: uploadSpy,
 		setNotDragging: notDraggingSpy,
 	}
-	const fileBrowser = shallow(<FileBrowser dragging={false} showRenameDialog={false} showUploadDialog={false} showDeleteDialog={false} showFileTransfers={false} actions={testActions} />)
+	const fileBrowser = shallow(<FileBrowser settingAllowance={false} dragging={false} showRenameDialog={false} showUploadDialog={false} showDeleteDialog={false} showFileTransfers={false} actions={testActions} />)
 	fileBrowser.find('.file-browser').first().simulate('drop', {
 		dataTransfer: {
 			files: files.map((file) => ({ path: file })),

--- a/test/files/filelist.component.js
+++ b/test/files/filelist.component.js
@@ -7,11 +7,11 @@ import FileList from '../../plugins/Files/js/components/filelist.js'
 
 const testFiles = List([
 	{size: '1337mb', available: true, redundancy: 1.0, name: 'hackers.mkv', siapath: 'movies/hackers.mkv', type: 'file'},
-	{size: '', name: 'movies', type: 'directory'},
+	{size: '', available: true, redundancy: 1.0,  name: 'movies', type: 'directory'},
 	{size: '137mb', available: true, redundancy: 1.5, name: 'test.jpg', siapath: 'test.jpg', type: 'file'},
 	{size: '137mb', available: true, redundancy: 2.0, name: 'meme.avi', siapath: 'meme.avi', type: 'file'},
 	{size: '137mb', available: true, redundancy: -1, name: 'test-0bytes', siapath: 'test-0bytes', type: 'file'},
-	{size: '', name: 'dankpepes', type: 'directory'},
+	{size: '', available: true, redundancy: 1.0, name: 'dankpepes', type: 'directory'},
 ])
 
 const testActions = {


### PR DESCRIPTION
This PR fixes a few `PropType` validation errors in tests, caused by adding required props to components without updating the tests.