### PR TITLE
fix parsing of files in file browser starting with '..'

### DIFF
--- a/plugins/Files/js/components/filelist.js
+++ b/plugins/Files/js/components/filelist.js
@@ -8,14 +8,20 @@ import DirectoryInfoBar from './directoryinfobar.js'
 
 const FileList = ({files, selected, searchResults, path, showSearchField, actions}) => {
 	const onBackClick = () => {
-		if (path === '') {
+		// remove a trailing slash if it exists
+		const cleanPath = path.replace(/\/$/, '')
+
+		if (cleanPath === '') {
 			return
 		}
-		let newpath = Path.posix.join(path, '../')
-		if (newpath === './') {
-			newpath = ''
+
+		// find the parent directory and set the new path
+		const pathComponents = cleanPath.split('/')
+		if (pathComponents.length < 2) {
+			actions.setPath('')
+		} else {
+			actions.setPath(pathComponents[pathComponents.length-2] + '/')
 		}
-		actions.setPath(newpath)
 	}
 
 	if (files === null) {

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -98,6 +98,12 @@ export const ls = (files, path) => {
 		if (relativePath.indexOf('/') !== -1) {
 			type = 'directory'
 			filename = relativePath.split('/')[0]
+
+			// directories cannot be named '..'.
+			if (filename === '..') {
+				return
+			}
+
 			siapath = Path.posix.join(path, filename) + '/'
 			const subfiles = files.filter((subfile) => subfile.siapath.includes(siapath))
 			const totalFilesize = subfiles.reduce((sum, subfile) => sum + subfile.filesize, 0)

--- a/test/files/helpers.js
+++ b/test/files/helpers.js
@@ -181,9 +181,9 @@ describe('files plugin helper functions', () => {
 				expect(output.toObject()).to.deep.equal(expectedOutputs[path].toObject())
 			}
 		})
-		it('should work with siapaths that have a folder ending in ..', () => {
+		it('should work with siapaths that have a folder or file ending in ..', () => {
 			const siapathInputs = List([
-				{ filesize: 1000, siapath: 'test/test.png', redundancy: 2.0, available: true, uploadprogress: 100 },
+				{ filesize: 1000, siapath: 'test/test/..test.png', redundancy: 2.0, available: true, uploadprogress: 100 },
 				{ filesize: 1000, siapath: 'test/test../test.png', redundancy: 2.0, available: true, uploadprogress: 100},
 			])
 			const expectedOutputs = {
@@ -191,9 +191,12 @@ describe('files plugin helper functions', () => {
 					{ size: readableFilesize(1000+1000), name: 'test', siapath: 'test/', redundancy: 2.0, available: true, uploadprogress: 100, type: 'directory' },
 				]),
 				'test': List([
+					{ size: readableFilesize(1000), name: 'test', siapath: 'test/test/', redundancy: 2.0, available: true, uploadprogress: 100, type: 'directory' },
 					{ size: readableFilesize(1000), name: 'test..', siapath: 'test/test../', redundancy: 2.0, available: true, uploadprogress: 100, type: 'directory' },
-					{ size: readableFilesize(1000), name: 'test.png', siapath: 'test/test.png', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
-				])
+				]),
+				'test/test': List([
+					{ size: readableFilesize(1000), name: '..test.png', siapath: 'test/test/..test.png', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
+				]),
 			}
 			for (const path in expectedOutputs) {
 				const output = ls(siapathInputs, path)

--- a/test/files/helpers.js
+++ b/test/files/helpers.js
@@ -137,48 +137,72 @@ describe('files plugin helper functions', () => {
 			expect(rangeSelect({ siapath: 'test4' }, testFiles, selected).toArray()).to.deep.equal(expectedSelection)
 		})
 	})
-	it('should ls a file list correctly', () => {
+	describe('ls', () => {
 		const lsWin32 = proxyquire('../../plugins/Files/js/sagas/helpers.js', {
 			'path': Path.win32,
 		}).ls
-		const siapathInputs = List([
-			{ filesize: 1337, siapath: 'folder/file.jpg', redundancy: 2.0, available: true, uploadprogress: 100 },
-			{ filesize: 13117, siapath: 'folder/file2.jpg', redundancy: 2.0, available: true, uploadprogress: 100 },
-			{ filesize: 1237, siapath: 'rare_pepe.png', redundancy: 2.0, available: true, uploadprogress: 100 },
-			{ filesize: 1317, siapath: 'memes/waddup.png', redundancy: 2.5, available: true, uploadprogress: 100 },
-			{ filesize: 1337, siapath: 'memes/itsdatboi.mov', redundancy: 2.0, available: true, uploadprogress: 100 },
-			{ filesize: 1337, siapath: 'memes/rares/lordkek.gif', redundancy: 1.6, available: true, uploadprogress: 100 },
-			{ filesize: 13117, siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 100 },
-			{ filesize: 13117, siapath: 'test_0bytes.avi', redundancy: -1, available: true, uploadprogress: 100 },
-			{ filesize: 1331, siapath: 'doggos/borkborkdoggo.png', redundancy: 1.5, available: true, uploadprogress: 100 },
-			{ filesize: 1333, siapath: 'doggos/snip_snip_doggo_not_bork_bork_kind.jpg', redundancy: 1.0, available: true, uploadprogress: 100 },
-		])
-		const expectedOutputs = {
-			'': List([
-				{ size: readableFilesize(1331+1333), name: 'doggos', siapath: 'doggos/', redundancy: 1.0, available: true, uploadprogress: 100, type: 'directory' },
-				{ size: readableFilesize(1337+13117), name: 'folder', siapath: 'folder/', redundancy: 2.0, available: true, uploadprogress: 100, type: 'directory' },
-				{ size: readableFilesize(1317+1337+1337), name: 'memes', siapath: 'memes/', redundancy: 1.6, available: true, uploadprogress: 100, type: 'directory' },
-				{ size: readableFilesize(1237), name: 'rare_pepe.png', siapath: 'rare_pepe.png', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
-				{ size: readableFilesize(13117), name: 'sibyl_system.avi', siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 100, type: 'file' },
-				{ size: readableFilesize(13117), name: 'test_0bytes.avi', siapath: 'test_0bytes.avi', redundancy: -1.0, available: true, uploadprogress: 100, type: 'file'},
-			]),
-			'doggos/': List([
-				{ size: readableFilesize(1331), name: 'borkborkdoggo.png', siapath: 'doggos/borkborkdoggo.png', redundancy: 1.5, available: true, uploadprogress: 100, type: 'file' },
-				{ size: readableFilesize(1333), name: 'snip_snip_doggo_not_bork_bork_kind.jpg', redundancy: 1.0, siapath: 'doggos/snip_snip_doggo_not_bork_bork_kind.jpg', available: true, uploadprogress: 100, type: 'file' },
-			]),
-			'memes/': List([
-				{ size: readableFilesize(1337), name: 'rares', siapath: 'memes/rares/', available: true, redundancy: 1.6, uploadprogress: 100, type: 'directory' },
-				{ size: readableFilesize(1337), name: 'itsdatboi.mov', siapath: 'memes/itsdatboi.mov', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
-				{ size: readableFilesize(1317), name: 'waddup.png', siapath: 'memes/waddup.png', available: true, redundancy: 2.5, uploadprogress: 100, type: 'file' },
-			]),
-		}
-		for (const path in expectedOutputs) {
-			const output = ls(siapathInputs, path)
-			const outputWin32 = lsWin32(siapathInputs, path)
-			expect(output).to.deep.equal(outputWin32)
-			expect(output.size).to.equal(expectedOutputs[path].size)
-			expect(output.toObject()).to.deep.equal(expectedOutputs[path].toObject())
-		}
+		it('should ls a file list correctly', () => {
+			const siapathInputs = List([
+				{ filesize: 1337, siapath: 'folder/file.jpg', redundancy: 2.0, available: true, uploadprogress: 100 },
+				{ filesize: 13117, siapath: 'folder/file2.jpg', redundancy: 2.0, available: true, uploadprogress: 100 },
+				{ filesize: 1237, siapath: 'rare_pepe.png', redundancy: 2.0, available: true, uploadprogress: 100 },
+				{ filesize: 1317, siapath: 'memes/waddup.png', redundancy: 2.5, available: true, uploadprogress: 100 },
+				{ filesize: 1337, siapath: 'memes/itsdatboi.mov', redundancy: 2.0, available: true, uploadprogress: 100 },
+				{ filesize: 1337, siapath: 'memes/rares/lordkek.gif', redundancy: 1.6, available: true, uploadprogress: 100 },
+				{ filesize: 13117, siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 100 },
+				{ filesize: 13117, siapath: 'test_0bytes.avi', redundancy: -1, available: true, uploadprogress: 100 },
+				{ filesize: 1331, siapath: 'doggos/borkborkdoggo.png', redundancy: 1.5, available: true, uploadprogress: 100 },
+				{ filesize: 1333, siapath: 'doggos/snip_snip_doggo_not_bork_bork_kind.jpg', redundancy: 1.0, available: true, uploadprogress: 100 },
+			])
+			const expectedOutputs = {
+				'': List([
+					{ size: readableFilesize(1331+1333), name: 'doggos', siapath: 'doggos/', redundancy: 1.0, available: true, uploadprogress: 100, type: 'directory' },
+					{ size: readableFilesize(1337+13117), name: 'folder', siapath: 'folder/', redundancy: 2.0, available: true, uploadprogress: 100, type: 'directory' },
+					{ size: readableFilesize(1317+1337+1337), name: 'memes', siapath: 'memes/', redundancy: 1.6, available: true, uploadprogress: 100, type: 'directory' },
+					{ size: readableFilesize(1237), name: 'rare_pepe.png', siapath: 'rare_pepe.png', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
+					{ size: readableFilesize(13117), name: 'sibyl_system.avi', siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 100, type: 'file' },
+					{ size: readableFilesize(13117), name: 'test_0bytes.avi', siapath: 'test_0bytes.avi', redundancy: -1.0, available: true, uploadprogress: 100, type: 'file'},
+				]),
+				'doggos/': List([
+					{ size: readableFilesize(1331), name: 'borkborkdoggo.png', siapath: 'doggos/borkborkdoggo.png', redundancy: 1.5, available: true, uploadprogress: 100, type: 'file' },
+					{ size: readableFilesize(1333), name: 'snip_snip_doggo_not_bork_bork_kind.jpg', redundancy: 1.0, siapath: 'doggos/snip_snip_doggo_not_bork_bork_kind.jpg', available: true, uploadprogress: 100, type: 'file' },
+				]),
+				'memes/': List([
+					{ size: readableFilesize(1337), name: 'rares', siapath: 'memes/rares/', available: true, redundancy: 1.6, uploadprogress: 100, type: 'directory' },
+					{ size: readableFilesize(1337), name: 'itsdatboi.mov', siapath: 'memes/itsdatboi.mov', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
+					{ size: readableFilesize(1317), name: 'waddup.png', siapath: 'memes/waddup.png', available: true, redundancy: 2.5, uploadprogress: 100, type: 'file' },
+				]),
+			}
+			for (const path in expectedOutputs) {
+				const output = ls(siapathInputs, path)
+				const outputWin32 = lsWin32(siapathInputs, path)
+				expect(output).to.deep.equal(outputWin32)
+				expect(output.size).to.equal(expectedOutputs[path].size)
+				expect(output.toObject()).to.deep.equal(expectedOutputs[path].toObject())
+			}
+		})
+		it('should work with siapaths that have a folder ending in ..', () => {
+			const siapathInputs = List([
+				{ filesize: 1000, siapath: 'test/test.png', redundancy: 2.0, available: true, uploadprogress: 100 },
+				{ filesize: 1000, siapath: 'test/test../test.png', redundancy: 2.0, available: true, uploadprogress: 100},
+			])
+			const expectedOutputs = {
+				'': List([
+					{ size: readableFilesize(1000+1000), name: 'test', siapath: 'test/', redundancy: 2.0, available: true, uploadprogress: 100, type: 'directory' },
+				]),
+				'test': List([
+					{ size: readableFilesize(1000), name: 'test..', siapath: 'test/test../', redundancy: 2.0, available: true, uploadprogress: 100, type: 'directory' },
+					{ size: readableFilesize(1000), name: 'test.png', siapath: 'test/test.png', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
+				])
+			}
+			for (const path in expectedOutputs) {
+				const output = ls(siapathInputs, path)
+				const outputWin32 = lsWin32(siapathInputs, path)
+				expect(output).to.deep.equal(outputWin32)
+				expect(output.size).to.equal(expectedOutputs[path].size)
+				expect(output.toObject()).to.deep.equal(expectedOutputs[path].toObject())
+			}
+		})
 	})
 	describe('minRedundancy', () => {
 		it('returns correct values for list of size 0', () => {


### PR DESCRIPTION
This PR fixes an issue with parsing siapaths in the file browser: previously, if a user uploaded a file with '..' in its name, an extra non-existent directory would appear and navigating to this directory would break the file browser. I added a test to demonstrate this bug and slightly changed the `ls` and `onBackClick` algorithms to fix the bug.