### PR TITLE
make closing behavior more obvious

### DIFF
--- a/js/rendererjs/index.js
+++ b/js/rendererjs/index.js
@@ -84,7 +84,7 @@ ipcRenderer.on('quit', async () => {
 let hasClosed = false
 window.onbeforeunload = () => {
 	if (window.closeToTray) {
-		mainWindow.hide()
+		mainWindow.minimize()
 		if (process.platform === 'win32' && !hasClosed) {
 			mainWindow.tray.displayBalloon({
 				title: 'Sia-UI information',

--- a/js/rendererjs/index.js
+++ b/js/rendererjs/index.js
@@ -84,7 +84,19 @@ ipcRenderer.on('quit', async () => {
 let hasClosed = false
 window.onbeforeunload = () => {
 	if (window.closeToTray) {
-		mainWindow.minimize()
+		if (mainWindow.isVisible() === false) {
+			shutdown()
+			return false
+		}
+
+		if (process.platform === 'linux') {
+			// minimize is not supported in all linux WM/DEs, so we hide instead
+			mainWindow.hide()
+		} else {
+			// minimize is supported by both windows and MacOS.
+			mainWindow.minimize()
+		}
+
 		if (process.platform === 'win32' && !hasClosed) {
 			mainWindow.tray.displayBalloon({
 				title: 'Sia-UI information',

--- a/test/app.js
+++ b/test/app.js
@@ -103,6 +103,7 @@ describe('startup and shutdown behaviour', () => {
 			app.browserWindow.close()
 			await sleep(1000)
 			expect(await app.browserWindow.isDestroyed()).to.be.false
+			expect(await app.browserWindow.isVisible()).to.be.false
 			expect(isProcessRunning(siadProcess.pid)).to.be.true
 		})
 		it('quits gracefully on close if closeToTray = false', async () => {
@@ -117,6 +118,21 @@ describe('startup and shutdown behaviour', () => {
 			while (await app.client.getText('#overlay-text') !== 'Quitting Sia...') {
 				await sleep(10)
 			}
+			while (isProcessRunning(pid)) {
+				await sleep(10)
+			}
+			expect(isProcessRunning(siadProcess.pid)).to.be.false
+		})
+		it('quits gracefully on close if already minimized and closed again', async () => {
+			const pid = await app.mainProcess.pid()
+			siadProcess = await getSiadChild(pid)
+			app.webContents.executeJavaScript('window.closeToTray = true')
+			app.browserWindow.close()
+			await sleep(1000)
+			expect(await app.browserWindow.isDestroyed()).to.be.false
+			expect(await app.browserWindow.isVisible()).to.be.false
+			expect(isProcessRunning(siadProcess.pid)).to.be.true
+			app.browserWindow.close()
 			while (isProcessRunning(pid)) {
 				await sleep(10)
 			}


### PR DESCRIPTION
Based on feedback on the forum and elsewhere, it has become apparent that the closing behavior of Sia-UI (closing to the task menu on windows, osx, and linux) is confusing for some users. This PR changes the behavior to minimize instead of hide the window, keeping it visible in the Windows taskbar. If the user then right clicks the Sia icon in the taskbar and clicks 'Close', a clean shutdown will be triggered. Sia-UI can still be quit from the task menu, but this should help users who are not used to that behavior and expect that the app is quit when it disappears from the taskbar.

