### PR TITLE
restore main window if hidden and quit is triggered

### DIFF
--- a/js/rendererjs/index.js
+++ b/js/rendererjs/index.js
@@ -85,6 +85,7 @@ let hasClosed = false
 window.onbeforeunload = () => {
 	if (window.closeToTray) {
 		if (mainWindow.isVisible() === false) {
+			mainWindow.restore()
 			shutdown()
 			return false
 		}


### PR DESCRIPTION
This causes the user to see the "Quitting" progress when they quit the UI and it is hidden.