### PR TITLE
add configuration options for RPC, Host, and API addresses

### DIFF
--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -8,6 +8,8 @@ const defaultConfig = {
 	siad: {
 		path: Path.join(__dirname, '../Sia/' + (process.platform === 'win32' ? 'siad.exe' : 'siad')),
 		datadir: Path.join(app.getPath('userData'), './sia'),
+		rpcaddr: ':9981',
+		hostaddr: ':9982',
 		detached: false,
 		address: 'localhost:9980',
 	},
@@ -26,12 +28,14 @@ export default function configManager(filepath) {
 	let config
 
 	try {
-		// TODO: write load() function instead of global require
 		const data = fs.readFileSync(filepath)
 		config = JSON.parse(data)
 	} catch (err) {
 		config = defaultConfig
 	}
+
+	// fill out default values if config is incomplete
+	config = Object.assign(defaultConfig, config)
 
 	/**
 	 * Gets or sets a config attribute

--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -94,6 +94,9 @@ export default async function loadingScreen(initUI) {
 	try {
 		const siadProcess = Siad.launch(siadConfig.path, {
 			'sia-directory': siadConfig.datadir,
+			'rpc-addr': siadConfig.rpcaddr,
+			'host-addr': siadConfig.hostaddr,
+			'api-addr': siadConfig.address,
 		})
 		siadProcess.on('error', (e) => showError('Siad couldnt start: ' + e.toString()))
 		siadProcess.on('close', () => showError('Siad unexpectedly closed.'))


### PR DESCRIPTION
This PR adds two new UI configuration options, `rpcaddr` and `hostaddr`, allowing users to change the ports that their siad binds to.