### PR TITLE
display siad's stderr on loadingscreen if load fails

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -274,7 +274,7 @@ html,body {
   height: 100%;
 
 	text-align: center;
-	font-size: 50px;
+	font-size: 35px;
 	background-color: #fff;
 	opacity: .5;
 }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 		<div class='overlay'>
 			<div class='centered'>
 				<p id="overlay-text"></p>
-				<i class='fa fa-spinner fa-pulse'></i>
+				<i id="loading-spinner" class='fa fa-spinner fa-pulse'></i>
 			</div>
 		</div>
 		<!-- Header for UI -->


### PR DESCRIPTION
This PR improves the behavior of the UI's loading process, reading and displaying the STDERR and STDOUT from siad if siad closes unexpectedly. This should help our users by giving them more information as to why their `siad` failed to start.