### PR TITLE
add error logging, bug report link to crash screen

### DIFF
--- a/js/rendererjs/disabledplugin.js
+++ b/js/rendererjs/disabledplugin.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react'
+import { shell } from 'electron'
 
 const containerStyle = {
 	display: 'flex',
@@ -10,14 +11,36 @@ const containerStyle = {
 	height: '100%',
 }
 
-const DisabledPlugin = ({startSiad}) => (
+const errorLogStyle = {
+	height: '300px',
+	width: '80%',
+	overflow: 'auto',
+	marginBottom: '15px',
+}
+
+const reportStyle = {
+	color: 'blue',
+	cursor: 'pointer',
+}
+
+const handleReport = () => {
+	shell.openExternal('https://github.com/NebulousLabs/Sia/issues')
+}
+
+
+const DisabledPlugin = ({errorMsg, startSiad}) => (
 	<div style={containerStyle}>
-		<h1>Siad has stopped.</h1>
+		<h2>Siad has exited unexpectedly. Please submit a bug report including the error log <a style={reportStyle} onClick={handleReport}>here.</a></h2>
+		<h2> Error Log: </h2>
+		<textarea style={errorLogStyle} readOnly>
+			{errorMsg}
+		</textarea>
 		<button onClick={startSiad}>Start Siad</button>
 	</div>
 )
 
 DisabledPlugin.propTypes = {
+	errorMsg: PropTypes.string.isRequired,
 	startSiad: PropTypes.func.isRequired,
 }
 

--- a/test/pluginapi.unit.js
+++ b/test/pluginapi.unit.js
@@ -39,6 +39,7 @@ const mock = {
 				showMessageBox: sinon.spy(),
 				showErrorBox: sinon.spy(),
 			},
+			require: sinon.spy(),
 		},
 	},
 }


### PR DESCRIPTION
This PR adds an error log to the crash screen, displaying `siad`'s STDERR and STDOUT log in the event of a crash, and also directs users to submit bug reports to the Sia repo in the event of an unexpected crash.

![sia1](https://cloud.githubusercontent.com/assets/8183920/24375301/cd59cea4-1305-11e7-9891-a6b8dca4f4bf.png)
