### PR TITLE
update plugin's state when they are opened

### DIFF
--- a/js/rendererjs/plugins.js
+++ b/js/rendererjs/plugins.js
@@ -57,6 +57,7 @@ export const setCurrentPlugin = (pluginName) => {
 	if (viewElem !== null) {
 		viewElem.classList.add('current')
 	}
+	viewElem.focus()
 
 	const buttonElem = document.getElementById(pluginName + '-button')
 	if (buttonElem !== null) {

--- a/plugins/Files/js/index.js
+++ b/plugins/Files/js/index.js
@@ -22,14 +22,7 @@ const rootElement = (
 )
 ReactDOM.render(rootElement, document.getElementById('react-root'))
 
-store.dispatch(getWalletLockstate())
-store.dispatch(getFiles())
-store.dispatch(getUploads())
-store.dispatch(getContractCount())
-store.dispatch(getWalletSyncstate())
-store.dispatch(getAllowance())
-
-setInterval(() => {
+const updateState = () => {
 	store.dispatch(getDownloads())
 	store.dispatch(getUploads())
 	store.dispatch(getWalletLockstate())
@@ -37,5 +30,14 @@ setInterval(() => {
 	store.dispatch(getWalletSyncstate())
 	store.dispatch(getContractCount())
 	store.dispatch(getAllowance())
-}, 3000)
+}
+
+// get initial state
+updateState()
+
+// update state every 3s
+setInterval(updateState, 3000)
+
+// update state when plugin is focused
+window.onfocus = updateState
 

--- a/plugins/Hosting/js/index.js
+++ b/plugins/Hosting/js/index.js
@@ -31,6 +31,11 @@ setInterval(() => {
 	store.dispatch(actions.fetchData())
 }, 5000)
 
+// update state immediately when this plugin is focused
+window.onfocus = () => {
+	store.dispatch(actions.fetchData())
+}
+
 // slightly longer poll for checking host connectability
 setInterval(() => {
 	store.dispatch(actions.getHostConnectabilityStatus())

--- a/plugins/Wallet/js/main.js
+++ b/plugins/Wallet/js/main.js
@@ -15,21 +15,23 @@ export const initWallet = () => {
 		applyMiddleware(sagaMiddleware)
 	)
 	sagaMiddleware.run(rootSaga)
-	// Get initial UI state
-	store.dispatch(getLockStatus())
-	store.dispatch(getBalance())
-	store.dispatch(getTransactions())
-	store.dispatch(getSyncState())
 
-	// Poll Siad for state changes.
-	setInterval(() => {
+	// Get initial UI state
+	const updateState = () => {
 		store.dispatch(getLockStatus())
 		if (store.getState().wallet.get('unlocked')) {
 			store.dispatch(getBalance())
 			store.dispatch(getTransactions())
 			store.dispatch(getSyncState())
 		}
-	}, 5000)
+	}
+
+	// Poll Siad for state changes
+	setInterval(updateState, 5000)
+
+	// update state when plugin is opened
+	window.onfocus = updateState
+
 	return (
 		<Provider store={store}>
 			<WalletApp />


### PR DESCRIPTION
This PR improves UX by updating the Files, Hosting, and Wallet states immediately when the plugins are opened, as well as polling frequently for data updates.