### PR TITLE
`OK` before `cancel` in wallet's sendprompt

### DIFF
--- a/plugins/Wallet/js/components/sendprompt.js
+++ b/plugins/Wallet/js/components/sendprompt.js
@@ -17,8 +17,8 @@ const SendPrompt = ({currencytype, sendAddress, sendAmount, actions}) => {
 					<input onChange={handleSendAddressChange} value={sendAddress} />
 				</div>
 				<div className="send-prompt-buttons">
-					<button className="cancel-send-button" onClick={handleCancelClick}>Cancel</button>
 					<button className="send-siacoin-button" onClick={handleSendClick}>Send</button>
+					<button className="cancel-send-button" onClick={handleCancelClick}>Cancel</button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This PR makes the button ordering of the wallet's `SendPrompt` component consistent with the button ordering in the rest of Sia-UI (OK before Cancel).

See #537 