### PR TITLE
add css animations to wallet, files plugins

### DIFF
--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -155,6 +155,11 @@ div[tabindex="1"]:focus {
 	margin-left: 25px;
 }
 
+@keyframes modal-fadein {
+	from {opacity: 0}
+	to {opacity: 1}
+}
+
 .modal {
 	position: absolute;
 	z-index: 1;
@@ -166,6 +171,9 @@ div[tabindex="1"]:focus {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
+	animation-name: modal-fadein;
+	animation-duration: 0.3s;
 }
 
 .files-toolbar h3 {
@@ -474,6 +482,19 @@ div[tabindex="1"]:focus {
 .allowance-input {
 	padding-right: 80px;
 }
+
+@keyframes allowance-dialog-popin {
+	0% {
+		width: 60%;
+	}
+	60% {
+		width: 85%;
+	}
+	100% {
+		width: 80%;
+	}
+}
+
 .allowance-dialog {
 	padding: 40px 40px 40px 40px;
 	display: flex;
@@ -484,7 +505,13 @@ div[tabindex="1"]:focus {
 	width: 50%;
 	height: 400px;
 	z-index: 10;
+
+	animation-name: allowance-dialog-popin;
+	animation-duration: 0.3s;
+
+	border-radius: 4px;
 }
+
 .allowance-input span {
 	display: inline-block;
 }

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -484,15 +484,8 @@ div[tabindex="1"]:focus {
 }
 
 @keyframes allowance-dialog-popin {
-	0% {
-		width: 60%;
-	}
-	60% {
-		width: 85%;
-	}
-	100% {
-		width: 80%;
-	}
+	from { transform: scale(0.2) }
+	to { transform: scale(1) }
 }
 
 .allowance-dialog {
@@ -507,7 +500,7 @@ div[tabindex="1"]:focus {
 	z-index: 10;
 
 	animation-name: allowance-dialog-popin;
-	animation-duration: 0.3s;
+	animation-duration: 0.2s;
 
 	border-radius: 4px;
 }

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -77,6 +77,12 @@ div[tabindex="1"]:focus {
 	margin-left: 10px;
 	margin-right: 10px;
 }
+
+@keyframes transfers-slidein {
+	from {width: 0}
+	to {width: 400px}
+}
+
 .file-transfers {
 	width: 400px;
 	height: 100%;
@@ -88,7 +94,11 @@ div[tabindex="1"]:focus {
 	align-items: center;
 	justify-content: flex-start;
 	background-color: #C5C5C5;
+
+	animation-name: transfers-slidein;
+	animation-duration: 0.3s;
 }
+
 .transfer-list {
 	width: 100%;
 	margin: 0;
@@ -144,6 +154,7 @@ div[tabindex="1"]:focus {
 .uploads h3, .downloads h3 {
 	margin-left: 25px;
 }
+
 .modal {
 	position: absolute;
 	z-index: 1;

--- a/plugins/Wallet/css/wallet.css
+++ b/plugins/Wallet/css/wallet.css
@@ -101,8 +101,8 @@
 	align-items: center;
 	justify-content: center;
 	flex-direction: column;
-	width: 70%;
-	height: 25%;
+	width: 500px;
+	height: 180px;
 	background-color: #ECECEC;
 }
 .wallet-toolbar {
@@ -132,18 +132,8 @@
 }
 
 @keyframes modal-popin {
-	0% {
-		width: 0%;
-		height: 0%;
-	}
-	60% {
-		width: 55%;
-		height: 55%;
-	}
-	100% {
-		width: 50%;
-		height: 50%;
-	}
+	from { transform: scale(0.2) }
+	to { transform: scale(1) }
 }
 
 .modal {
@@ -163,11 +153,9 @@
 
 .modal > * {
 	animation-name: modal-popin;
-	animation-duration: 0.3s;
+	animation-duration: 0.2s;
 
 	border-radius: 5px;
-	width: 50%;
-	height: 50%;
 }
 
 .sendprompt {
@@ -319,9 +307,9 @@
 	justify-content: center;
 	flex-direction: column;
 	background-color: #eee;
-	padding-left: 10px;
-	padding-right: 10px;
-	padding-bottom: 10px;
+	padding-left: 30px;
+	padding-right: 30px;
+	padding-bottom: 30px;
 }
 .recovery-form-buttons {
 	margin-top: 15px;

--- a/plugins/Wallet/css/wallet.css
+++ b/plugins/Wallet/css/wallet.css
@@ -125,6 +125,27 @@
 	font-size: 15px;
 	margin-bottom: 3px;
 }
+
+@keyframes modal-fadein {
+	from {opacity: 0}
+	to {opacity: 1}
+}
+
+@keyframes modal-popin {
+	0% {
+		width: 0%;
+		height: 0%;
+	}
+	60% {
+		width: 55%;
+		height: 55%;
+	}
+	100% {
+		width: 50%;
+		height: 50%;
+	}
+}
+
 .modal {
 	position: absolute;
 	top: 0;
@@ -135,7 +156,20 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
+	animation-name: modal-fadein;
+	animation-duration: 0.2s;
 }
+
+.modal > * {
+	animation-name: modal-popin;
+	animation-duration: 0.3s;
+
+	border-radius: 5px;
+	width: 50%;
+	height: 50%;
+}
+
 .sendprompt {
 	display: flex;
 	flex-direction: column;
@@ -284,8 +318,6 @@
 	align-items: center;
 	justify-content: center;
 	flex-direction: column;
-	width: 50%;
-	height: 300px;
 	background-color: #eee;
 	padding-left: 10px;
 	padding-right: 10px;


### PR DESCRIPTION
This PR adds a few CSS animations to the Files and Wallet plugins, most notably fade-in and pop-in (with a bounce-type effect) for the modal windows and a slide-in animation for the Files plugin's File Transfers panel.