### PR TITLE
dont launch siad with miner module

### DIFF
--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -110,6 +110,7 @@ export default async function loadingScreen(initUI) {
 			'rpc-addr': siadConfig.rpcaddr,
 			'host-addr': siadConfig.hostaddr,
 			'api-addr': siadConfig.address,
+			'modules': 'cghrtw',
 		})
 		siadProcess.on('error', (e) => showError('Siad couldnt start: ' + e.toString()))
 		siadProcess.on('close', unexpectedExitHandler)

--- a/js/rendererjs/pluginapi.js
+++ b/js/rendererjs/pluginapi.js
@@ -45,6 +45,7 @@ window.onload = async function() {
 			'rpc-addr': siadConfig.rpcaddr,
 			'host-addr': siadConfig.hostaddr,
 			'api-addr': siadConfig.address,
+			'modules': 'cghrtw',
 		})
 		siadProcess.on('error', renderSiadCrashlog)
 		siadProcess.on('close', renderSiadCrashlog)


### PR DESCRIPTION
Nodejs-Sia's `launch` function uses the miner module by default, this PR changes the UI to only launch using consensus, gateway, host, renter, tpool, and wallet modules.