### PR TITLE
try the default siad path if it cannot be located on load

### DIFF
--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -2,11 +2,13 @@ import fs from 'graceful-fs'
 import Path from 'path'
 import { app } from 'electron'
 
+const defaultSiadPath = Path.join(__dirname, '../Sia/' + (process.platform === 'win32' ? 'siad.exe' : 'siad'))
+
 // The default settings
 const defaultConfig = {
 	homePlugin:  'Overview',
 	siad: {
-		path: Path.join(__dirname, '../Sia/' + (process.platform === 'win32' ? 'siad.exe' : 'siad')),
+		path: defaultSiadPath,
 		datadir: Path.join(app.getPath('userData'), './sia'),
 		rpcaddr: ':9981',
 		hostaddr: ':9982',
@@ -67,8 +69,12 @@ export default function configManager(filepath) {
 		config = configManager(filepath)
 	}
 
+	// expose the default siad path
+	config.defaultSiadPath = defaultSiadPath
+
 	// Save to disk immediately when loaded
 	config.save()
+
 	// Return the config object with the above 3 member functions
 	return config
 }

--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -45,9 +45,9 @@ const startUI = (welcomeMsg, initUI) => {
 	})
 }
 
-// checkSiaPath validates config's Sia path.
-// returns a promise that is resolved with `true` if siadConfig.path exists
-// or `false` if it does not exist.
+// checkSiaPath validates config's Sia path.  returns a promise that is
+// resolved with `true` if siadConfig.path exists or `false` if it does not
+// exist.
 const checkSiaPath = () => new Promise((resolve) => {
 	fs.stat(siadConfig.path, (err) => {
 		if (!err) {
@@ -86,9 +86,14 @@ export default async function loadingScreen(initUI) {
 		return
 	}
 
-	// Check siadConfig.path, and ask for a new path if siad doesn't exist.
-	const exists = await checkSiaPath(siadConfig.path)
-	if (!exists) {
+	// check siadConfig.path, if it doesn't exist optimistically set it to the
+	// default path
+	if (!await checkSiaPath(siadConfig.path)) {
+		siadConfig.path = config.defaultSiadPath
+	}
+
+	// check siadConfig.path, and ask for a new path if siad doesn't exist.
+	if (!await checkSiaPath(siadConfig.path)) {
 		// config.path doesn't exist.  Prompt the user for siad's location
 		dialog.showErrorBox('Siad not found', 'Sia-UI couldn\'t locate siad.  Please navigate to siad.')
 		const siadPath = dialog.showOpenDialog({
@@ -103,6 +108,7 @@ export default async function loadingScreen(initUI) {
 		}
 		siadConfig.path = siadPath[0]
 	}
+
 	// Launch the new Siad process
 	try {
 		const siadProcess = Siad.launch(siadConfig.path, {


### PR DESCRIPTION
This PR makes the loadingscreen a bit smarter, it will now try the default siad path (`Sia/siad`) if the path loaded from `config.json` does not exist. This solves an issue where users who rename `Sia-UI.app` on Mac are prompted to relocate `siad`.