### PR TITLE
Status polling

### DIFF
--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -32,13 +32,19 @@ const startUI = (welcomeMsg, initUI) => {
 
 	// Construct the status bar component and poll for updates from Siad
 	const updateSyncStatus = async function() {
-		const consensusData = await Siad.call(siadConfig.address, '/consensus')
-		const gatewayData = await Siad.call(siadConfig.address, '/gateway')
-		ReactDOM.render(<StatusBar peers={gatewayData.peers.length} synced={consensusData.synced} blockheight={consensusData.height} />, document.getElementById('statusbar'))
+		try {
+			const consensusData = await Siad.call(siadConfig.address, {timeout: 500, url: '/consensus'})
+			const gatewayData = await Siad.call(siadConfig.address, {timeout: 500, url: '/gateway'})
+			ReactDOM.render(<StatusBar peers={gatewayData.peers.length} synced={consensusData.synced} blockheight={consensusData.height} />, document.getElementById('statusbar'))
+			await new Promise((resolve) => setTimeout(resolve, 5000))
+		} catch (e) {
+			await new Promise((resolve) => setTimeout(resolve, 500))
+			console.error('error updating sync status: ' + e.toString())
+		}
+		updateSyncStatus()
 	}
 
 	updateSyncStatus()
-	setInterval(updateSyncStatus, 1000)
 
 	initUI(() => {
 		overlay.style.display = 'none'

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",
     "redux-saga": "^0.13.0",
-    "sia.js": "^0.3.4",
+    "sia.js": "^0.3.5",
     "webpack": "^1.13.1"
   },
   "scripts": {


### PR DESCRIPTION
previously, the status update async function was called every 1 second no matter what, meaning that if the /consensus endpoint was ever unresponsive (such as during unlocking), lots of HTTP calls could build up and on some platforms this could cause the OS's file handle limit to be reached. This PR removes that behavior, status calls now occur one after another. I also updated sia.js to 0.3.5, which uses a concurrent request limit of 40 instead of 100. This should solve https://github.com/NebulousLabs/Sia/issues/1702 - manually testing with a ulimit -n 256 (the limit on OSX Sierra) is successful. 