### PR TITLE
make 'checking host status' icon spin

### DIFF
--- a/plugins/Hosting/js/components/hoststatus.js
+++ b/plugins/Hosting/js/components/hoststatus.js
@@ -4,7 +4,7 @@ const HostStatus = ({connectabilitystatus, workingstatus}) => {
 	if (connectabilitystatus === 'checking' && workingstatus === 'checking') {
 		return (
 			<div className="host-status">
-				<i className="fa fa-refresh inactive-icon" />
+				<i className="fa fa-refresh fa-spin inactive-icon" />
 				<span> Checking Host Status... </span>
 				<div className="host-status-info">
 					Sia-UI is determining the status of your Host.


### PR DESCRIPTION
This should make users a little less worried about having a 'frozen' status icon, since checking host status takes 15 minutes.