### PR TITLE
only display 'Host Unreachable' if not connectable and not working

### DIFF
--- a/plugins/Hosting/js/components/hoststatus.js
+++ b/plugins/Hosting/js/components/hoststatus.js
@@ -13,7 +13,7 @@ const HostStatus = ({connectabilitystatus, workingstatus}) => {
 		)
 	}
 
-	if (connectabilitystatus === 'not connectable') {
+	if (connectabilitystatus === 'not connectable' && workingstatus === 'not working') {
 		return (
 			<div className="host-status">
 				<i className="fa fa-times offline-icon" />


### PR DESCRIPTION
Previously `Unreachable` would be displayed if the host was not connectable, regardless of the working state.