### PR TITLE
replace electron version in OSX .app in build script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -57,6 +57,7 @@ buildOSX() {
 	mv Sia-UI.app/Contents/MacOS/Electron Sia-UI.app/Contents/MacOS/Sia-UI
 	# NOTE: this only works with GNU sed, other platforms (like OSX) may fail here
 	sed -i 's/>Electron</>Sia-UI</' Sia-UI.app/Contents/Info.plist 
+	sed -i 's/>'"${electronVersion:1}"'</>'"${siaVersion:1}"'</' Sia-UI.app/Contents/Info.plist
 	sed -i 's/>com.github.electron\</>com.nebulouslabs.siaui</' Sia-UI.app/Contents/Info.plist
 	sed -i 's/>electron.icns</>icon.icns</' Sia-UI.app/Contents/Info.plist
 	cp ../../assets/icon.icns Sia-UI.app/Contents/Resources/


### PR DESCRIPTION
This PR adds version substitution to the existing .plist modification in the build script, replacing the Electron version with `siaVersion`.