### PR TITLE
Removed maxRedundancy

### DIFF
--- a/plugins/Files/js/components/redundancystatus.js
+++ b/plugins/Files/js/components/redundancystatus.js
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react'
 
 const colorNotAvailable = '#FF8080'
 const colorGoodRedundancy = '#00CBA0'
-const maxRedundancy = 6
 
 const RedundancyStatus = ({available, redundancy}) => {
 	const indicatorStyle = {
@@ -10,7 +9,7 @@ const RedundancyStatus = ({available, redundancy}) => {
 			if (!available || redundancy < 1.0) {
 				return 1
 			}
-			return redundancy/maxRedundancy
+			return redundancy
 		})(),
 		color: (() => {
 			if (!available || redundancy < 1.0) {


### PR DESCRIPTION
Since changing the maximum redundancy, newly uploaded files (with full redundancy) would show some opacity.

<img width="118" alt="screen shot 2017-04-26 at 9 20 35 pm" src="https://cloud.githubusercontent.com/assets/729707/25468472/ed9ca79a-2aca-11e7-90ca-afc8c68c6990.png">

<img width="114" alt="screen shot 2017-04-26 at 9 48 54 pm" src="https://cloud.githubusercontent.com/assets/729707/25468474/f16bce0a-2aca-11e7-9170-8cee0362120a.png">
