### PR TITLE
Redundancy opacity

### DIFF
--- a/plugins/Files/js/components/file.js
+++ b/plugins/Files/js/components/file.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react'
 import RedundancyStatus from './redundancystatus.js'
 
-const File = ({filename, type, selected, filesize, available, redundancy, onDoubleClick, onClick}) => (
+const File = ({filename, type, selected, filesize, available, redundancy, uploadprogress, onDoubleClick, onClick}) => (
 	<li onClick={onClick} onDoubleClick={onDoubleClick} className={selected ? 'filebrowser-file selected' : 'filebrowser-file'}>
 		<div className="filename">
 			{type === 'file' ? <i className="fa fa-file" /> : <i className="fa fa-folder" onClick={onDoubleClick} />}
@@ -9,7 +9,7 @@ const File = ({filename, type, selected, filesize, available, redundancy, onDoub
 		</div>
 		<div className="file-info">
 			<span className="filesize">{filesize}</span>
-			<RedundancyStatus available={available} redundancy={redundancy} />
+			<RedundancyStatus available={available} redundancy={redundancy} uploadprogress={uploadprogress} />
 		</div>
 	</li>
 )
@@ -20,6 +20,7 @@ File.propTypes = {
 	filesize: PropTypes.string.isRequired,
 	available: PropTypes.bool.isRequired,
 	redundancy: PropTypes.number,
+	uploadprogress: PropTypes.number,
 	selected: PropTypes.bool.isRequired,
 	onDoubleClick: PropTypes.func.isRequired,
 	onClick: PropTypes.func.isRequired,

--- a/plugins/Files/js/components/filelist.js
+++ b/plugins/Files/js/components/filelist.js
@@ -70,6 +70,7 @@ const FileList = ({files, selected, searchResults, path, showSearchField, action
 				filename={file.name}
 				filesize={file.size}
 				redundancy={file.redundancy}
+				uploadprogress={file.uploadprogress}
 				available={file.available}
 				onDoubleClick={onDoubleClick}
 				type={file.type}

--- a/plugins/Files/js/components/redundancystatus.js
+++ b/plugins/Files/js/components/redundancystatus.js
@@ -2,15 +2,17 @@ import React, { PropTypes } from 'react'
 
 const colorNotAvailable = '#FF8080'
 const colorGoodRedundancy = '#00CBA0'
-const maxRedundancy = 6
 
-const RedundancyStatus = ({available, redundancy}) => {
+const RedundancyStatus = ({available, redundancy, uploadprogress}) => {
 	const indicatorStyle = {
 		opacity: (() => {
 			if (!available || redundancy < 1.0) {
 				return 1
 			}
-			return redundancy/maxRedundancy
+			if (uploadprogress > 100) {
+				return 1
+			}
+			return uploadprogress/100
 		})(),
 		color: (() => {
 			if (!available || redundancy < 1.0) {
@@ -30,6 +32,7 @@ const RedundancyStatus = ({available, redundancy}) => {
 RedundancyStatus.propTypes = {
 	available: PropTypes.bool.isRequired,
 	redundancy: PropTypes.number.isRequired,
+	uploadprogress: PropTypes.number.isRequired,
 }
 
 export default RedundancyStatus

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -76,7 +76,7 @@ export const minUpload = (files) => {
 		return 0
 	}
 
-  // return the minimum upload progress of all the files
+	// return the minimum upload progress of all the files
 	return files.min((a, b) => {
 		if (a.uploadprogress > b.uploadprogress) {
 			return 1

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -76,15 +76,8 @@ export const minUpload = (files) => {
 		return 0
 	}
 
-	// return the minimum upload progress of all the files
-	return files.min((a, b) => {
-		if (a.uploadprogress > b.uploadprogress) {
-			return 1
-		}
-		return -1
-	}).uploadprogress
+	return files.map((f) => f.uploadprogress).min()
 }
-
 // directoriesFirst is a comparator function used to sort files by type, where
 // the directories will always come first.
 const directoriesFirst = (file1, file2) => {

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -69,6 +69,22 @@ export const minRedundancy = (files) => {
 	}).redundancy
 }
 
+// minUpload takes a list of files and returns the minimum upload progress that
+// occurs in the list.
+export const minUpload = (files) => {
+	if (files.size === 0) {
+		return 0
+	}
+
+  // return the minimum upload progress of all the files
+	return files.min((a, b) => {
+		if (a.uploadprogress > b.uploadprogress) {
+			return 1
+		}
+		return -1
+	}).uploadprogress
+}
+
 // directoriesFirst is a comparator function used to sort files by type, where
 // the directories will always come first.
 const directoriesFirst = (file1, file2) => {
@@ -90,7 +106,7 @@ export const ls = (files, path) => {
 		let type = 'file'
 		const relativePath = Path.posix.relative(path, file.siapath)
 		let filename = Path.posix.basename(relativePath)
-		const uploadprogress = Math.floor(file.uploadprogress)
+		let uploadprogress = Math.floor(file.uploadprogress)
 		let siapath = file.siapath
 		let filesize = readableFilesize(file.filesize)
 		let redundancy = file.redundancy
@@ -108,6 +124,7 @@ export const ls = (files, path) => {
 			const totalFilesize = subfiles.reduce((sum, subfile) => sum + subfile.filesize, 0)
 			filesize = readableFilesize(totalFilesize)
 			redundancy = minRedundancy(subfiles)
+			uploadprogress = minUpload(subfiles)
 		}
 		if (parsedFiles.has(filename) && parsedFiles.get(filename).type === type) {
 			return

--- a/test/files/filelist.component.js
+++ b/test/files/filelist.component.js
@@ -6,12 +6,12 @@ import { spy } from 'sinon'
 import FileList from '../../plugins/Files/js/components/filelist.js'
 
 const testFiles = List([
-	{size: '1337mb', available: true, redundancy: 1.0, name: 'hackers.mkv', siapath: 'movies/hackers.mkv', type: 'file'},
-	{size: '', available: true, redundancy: 1.0,  name: 'movies', type: 'directory'},
-	{size: '137mb', available: true, redundancy: 1.5, name: 'test.jpg', siapath: 'test.jpg', type: 'file'},
-	{size: '137mb', available: true, redundancy: 2.0, name: 'meme.avi', siapath: 'meme.avi', type: 'file'},
-	{size: '137mb', available: true, redundancy: -1, name: 'test-0bytes', siapath: 'test-0bytes', type: 'file'},
-	{size: '', available: true, redundancy: 1.0, name: 'dankpepes', type: 'directory'},
+	{size: '1337mb', available: true, redundancy: 1.0, uploadprogress: 100, name: 'hackers.mkv', siapath: 'movies/hackers.mkv', type: 'file'},
+	{size: '', available: true, redundancy: 1.0, uploadprogress: 100, name: 'movies', type: 'directory'},
+	{size: '137mb', available: true, redundancy: 1.5, uploadprogress: 100, name: 'test.jpg', siapath: 'test.jpg', type: 'file'},
+	{size: '137mb', available: true, redundancy: 2.0, uploadprogress: 100, name: 'meme.avi', siapath: 'meme.avi', type: 'file'},
+	{size: '137mb', available: true, redundancy: -1, uploadprogress: 100, name: 'test-0bytes', siapath: 'test-0bytes', type: 'file'},
+	{size: '', available: true, redundancy: 1.0, uploadprogress: 100, name: 'dankpepes', type: 'directory'},
 ])
 
 const testActions = {

--- a/test/files/helpers.js
+++ b/test/files/helpers.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { minRedundancy, uploadDirectory, rangeSelect, readableFilesize, ls } from '../../plugins/Files/js/sagas/helpers.js'
+import { minRedundancy, minUpload, uploadDirectory, rangeSelect, readableFilesize, ls } from '../../plugins/Files/js/sagas/helpers.js'
 import { List, OrderedSet } from 'immutable'
 import proxyquire from 'proxyquire'
 import Path from 'path'
@@ -143,13 +143,13 @@ describe('files plugin helper functions', () => {
 		}).ls
 		it('should ls a file list correctly', () => {
 			const siapathInputs = List([
-				{ filesize: 1337, siapath: 'folder/file.jpg', redundancy: 2.0, available: true, uploadprogress: 100 },
+				{ filesize: 1337, siapath: 'folder/file.jpg', redundancy: 2.0, available: true, uploadprogress: 50 },
 				{ filesize: 13117, siapath: 'folder/file2.jpg', redundancy: 2.0, available: true, uploadprogress: 100 },
 				{ filesize: 1237, siapath: 'rare_pepe.png', redundancy: 2.0, available: true, uploadprogress: 100 },
-				{ filesize: 1317, siapath: 'memes/waddup.png', redundancy: 2.5, available: true, uploadprogress: 100 },
-				{ filesize: 1337, siapath: 'memes/itsdatboi.mov', redundancy: 2.0, available: true, uploadprogress: 100 },
-				{ filesize: 1337, siapath: 'memes/rares/lordkek.gif', redundancy: 1.6, available: true, uploadprogress: 100 },
-				{ filesize: 13117, siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 100 },
+				{ filesize: 1317, siapath: 'memes/waddup.png', redundancy: 2.5, available: true, uploadprogress: 10 },
+				{ filesize: 1337, siapath: 'memes/itsdatboi.mov', redundancy: 2.0, available: true, uploadprogress: 20 },
+				{ filesize: 1337, siapath: 'memes/rares/lordkek.gif', redundancy: 1.6, available: true, uploadprogress: 30 },
+				{ filesize: 13117, siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 75 },
 				{ filesize: 13117, siapath: 'test_0bytes.avi', redundancy: -1, available: true, uploadprogress: 100 },
 				{ filesize: 1331, siapath: 'doggos/borkborkdoggo.png', redundancy: 1.5, available: true, uploadprogress: 100 },
 				{ filesize: 1333, siapath: 'doggos/snip_snip_doggo_not_bork_bork_kind.jpg', redundancy: 1.0, available: true, uploadprogress: 100 },
@@ -157,10 +157,10 @@ describe('files plugin helper functions', () => {
 			const expectedOutputs = {
 				'': List([
 					{ size: readableFilesize(1331+1333), name: 'doggos', siapath: 'doggos/', redundancy: 1.0, available: true, uploadprogress: 100, type: 'directory' },
-					{ size: readableFilesize(1337+13117), name: 'folder', siapath: 'folder/', redundancy: 2.0, available: true, uploadprogress: 100, type: 'directory' },
-					{ size: readableFilesize(1317+1337+1337), name: 'memes', siapath: 'memes/', redundancy: 1.6, available: true, uploadprogress: 100, type: 'directory' },
+					{ size: readableFilesize(1337+13117), name: 'folder', siapath: 'folder/', redundancy: 2.0, available: true, uploadprogress: 50, type: 'directory' },
+					{ size: readableFilesize(1317+1337+1337), name: 'memes', siapath: 'memes/', redundancy: 1.6, available: true, uploadprogress: 10, type: 'directory' },
 					{ size: readableFilesize(1237), name: 'rare_pepe.png', siapath: 'rare_pepe.png', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
-					{ size: readableFilesize(13117), name: 'sibyl_system.avi', siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 100, type: 'file' },
+					{ size: readableFilesize(13117), name: 'sibyl_system.avi', siapath: 'sibyl_system.avi', redundancy: 1.0, available: true, uploadprogress: 75, type: 'file' },
 					{ size: readableFilesize(13117), name: 'test_0bytes.avi', siapath: 'test_0bytes.avi', redundancy: -1.0, available: true, uploadprogress: 100, type: 'file'},
 				]),
 				'doggos/': List([
@@ -168,9 +168,9 @@ describe('files plugin helper functions', () => {
 					{ size: readableFilesize(1333), name: 'snip_snip_doggo_not_bork_bork_kind.jpg', redundancy: 1.0, siapath: 'doggos/snip_snip_doggo_not_bork_bork_kind.jpg', available: true, uploadprogress: 100, type: 'file' },
 				]),
 				'memes/': List([
-					{ size: readableFilesize(1337), name: 'rares', siapath: 'memes/rares/', available: true, redundancy: 1.6, uploadprogress: 100, type: 'directory' },
-					{ size: readableFilesize(1337), name: 'itsdatboi.mov', siapath: 'memes/itsdatboi.mov', redundancy: 2.0, available: true, uploadprogress: 100, type: 'file' },
-					{ size: readableFilesize(1317), name: 'waddup.png', siapath: 'memes/waddup.png', available: true, redundancy: 2.5, uploadprogress: 100, type: 'file' },
+					{ size: readableFilesize(1337), name: 'rares', siapath: 'memes/rares/', available: true, redundancy: 1.6, uploadprogress: 30, type: 'directory' },
+					{ size: readableFilesize(1337), name: 'itsdatboi.mov', siapath: 'memes/itsdatboi.mov', redundancy: 2.0, available: true, uploadprogress: 20, type: 'file' },
+					{ size: readableFilesize(1317), name: 'waddup.png', siapath: 'memes/waddup.png', available: true, redundancy: 2.5, uploadprogress: 10, type: 'file' },
 				]),
 			}
 			for (const path in expectedOutputs) {
@@ -219,6 +219,14 @@ describe('files plugin helper functions', () => {
 		})
 		it('returns correct values for a list of only negative redundancy', () => {
 			expect(minRedundancy(List([{redundancy: -1}, {redundancy: -1}]))).to.equal(-1)
+		})
+	})
+	describe('minUpload', () => {
+		it('returns correct values for list of size 0', () => {
+			expect(minUpload(List())).to.equal(0)
+		})
+		it('returns correct values given a list of files', () => {
+			expect(minUpload(List([{uploadprogress: 10}, {uploadprogress: 25}, {uploadprogress: 100}, {uploadprogress: 115}]))).to.equal(10)
 		})
 	})
 })


### PR DESCRIPTION
Each files redundancy status icon's opacity was hardcoded as `redundancy/6`. I've changed it to `uploadprogress/100`. Hopefully this is a little more robust if max redundancy is changed in the future or a user has files with different redundancy values.

Before:
<img width="111" alt="screen shot 2017-04-27 at 12 22 22 am" src="https://cloud.githubusercontent.com/assets/729707/25472304/9fe40dee-2adf-11e7-9eb4-698c7aed3a9f.png">

After:
<img width="121" alt="screen shot 2017-04-27 at 12 22 05 am" src="https://cloud.githubusercontent.com/assets/729707/25472307/a390d36e-2adf-11e7-8d11-acc90e3ebfa3.png">


