### PR TITLE
move config.json to userData

### DIFF
--- a/js/mainjs/index.js
+++ b/js/mainjs/index.js
@@ -4,7 +4,7 @@ import loadConfig from './config.js'
 import initWindow from './initWindow.js'
 
 // load config.json manager
-global.config = loadConfig(Path.join(__dirname, '../config.json'))
+global.config = loadConfig(Path.join(app.getPath('userData'), 'config.json'))
 let mainWindow
 
 // Allow only one instance of Sia-UI

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-3": "^6.5.0",
     "bignumber.js": "^2.1.3",
-    "electron": "^1.6.4",
+    "electron": "^1.6.7",
     "graceful-fs": "^4.1.11",
     "immutable": "^3.8.1",
     "json-loader": "^0.5.4",

--- a/test/app.js
+++ b/test/app.js
@@ -112,12 +112,6 @@ describe('startup and shutdown behaviour', () => {
 			expect(siadProcess.exists).to.be.true
 
 			app.browserWindow.close()
-			while (await app.client.isVisible('#overlay-text') === false) {
-				await sleep(10)
-			}
-			while (await app.client.getText('#overlay-text') !== 'Quitting Sia...') {
-				await sleep(10)
-			}
 			while (isProcessRunning(pid)) {
 				await sleep(10)
 			}


### PR DESCRIPTION
this PR moves `config.json` to `userData` (the same location where Sia's data is stored), instead of inside the app bundle. This will preserve UI settings across upgrades but more importantly it means that `Sia-UI.app` will run perfectly fine on read-only filesystems, solving #395 and making it so users do not have to move the app before using it.

This has been tested using the latest Mac OS X Sierra.