### PR TITLE
change error log to a scrolling textarea

### DIFF
--- a/css/general.css
+++ b/css/general.css
@@ -266,6 +266,19 @@ html,body {
 }
 
 /* Misc */
+#errorlog {
+	display: none;
+	color: #000;
+	font-size: 20px;
+	resize: none;
+	overflow: auto;
+	width: 700px;
+	height: 500px;
+	border: none;
+	outline: none;
+	box-shadow: none;
+}
+
 .overlay {
 	display: inline-flex;
   z-index: 10;

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 		<div class='overlay'>
 			<div class='centered'>
 				<p id="overlay-text"></p>
+				<textarea id="errorlog" class="error-log"></textarea>
 				<i id="loading-spinner" class='fa fa-spinner fa-pulse'></i>
 			</div>
 		</div>

--- a/js/rendererjs/loadingScreen.js
+++ b/js/rendererjs/loadingScreen.js
@@ -17,10 +17,13 @@ const siadConfig = config.attr('siad')
 const spinner = document.getElementById('loading-spinner')
 const overlay = document.getElementsByClassName('overlay')[0]
 const overlayText = overlay.getElementsByClassName('centered')[0].getElementsByTagName('p')[0]
+const errorLog = document.getElementById('errorlog')
 overlayText.textContent = 'Loading Sia...'
 
 const showError = (error) => {
-	overlayText.textContent = 'A Sia-UI error has occured: ' + error
+	overlayText.style.display = 'none'
+	errorLog.textContent = 'A critical error loading Sia has occured: ' + error
+	errorLog.style.display = 'inline-block'
 	spinner.style.display = 'none'
 }
 


### PR DESCRIPTION
this PR updates the loading screen so that the error log is a scrolling textarea, so users can easily copy+paste fatal loading errors.