### PR TITLE
get sync state even when wallet is locked

### DIFF
--- a/plugins/Wallet/js/main.js
+++ b/plugins/Wallet/js/main.js
@@ -19,10 +19,10 @@ export const initWallet = () => {
 	// Get initial UI state
 	const updateState = () => {
 		store.dispatch(getLockStatus())
+		store.dispatch(getSyncState())
 		if (store.getState().wallet.get('unlocked')) {
 			store.dispatch(getBalance())
 			store.dispatch(getTransactions())
-			store.dispatch(getSyncState())
 		}
 	}
 


### PR DESCRIPTION
this pr changes the wallet's polling so it will update the sync status even when the wallet is locked. This fixes a minor issue where users would see 'Wallet is not synced, balances are not final...' under the lock screen when the wallet was synced.
