### PR TITLE
if an error occurs loading seed, reset wallet state

### DIFF
--- a/plugins/Wallet/js/sagas/wallet.js
+++ b/plugins/Wallet/js/sagas/wallet.js
@@ -111,6 +111,9 @@ function *createWalletSaga(action) {
 		yield take(constants.SET_UNLOCKED)
 		yield put(actions.dismissNewWalletDialog())
 	} catch (e) {
+		if (initSeed) {
+			yield put(actions.initSeedFinished())
+		}
 		sendError(e)
 	}
 }


### PR DESCRIPTION
this PR fixes an issue where a user could encounter an error loading a seed using the UI, and they would stay on the 'loading seed' screen instead of being returned to the uninitialized wallet dialog.