### PR TITLE
don't display the lockscreen if we are initializing a seed

### DIFF
--- a/plugins/Wallet/js/components/lockscreen.js
+++ b/plugins/Wallet/js/components/lockscreen.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react'
 import PasswordPrompt from '../containers/passwordprompt.js'
 import UninitializedWalletDialog from '../containers/uninitializedwalletdialog.js'
 
-const LockScreen = ({unlocked, unlocking, encrypted}) => {
+const LockScreen = ({unlocked, unlocking, encrypted, initializingSeed}) => {
 	if (unlocked && encrypted && !unlocking) {
 		// Wallet is unlocked and encrypted, return an empty lock screen.
 		return (
@@ -10,11 +10,11 @@ const LockScreen = ({unlocked, unlocking, encrypted}) => {
 		)
 	}
 	let lockscreenContents
-	if (!unlocked && encrypted) {
+	if (!unlocked && encrypted && !initializingSeed) {
 		lockscreenContents = (
 			<PasswordPrompt />
 		)
-	} else  if (!encrypted) {
+	} else if (!encrypted || initializingSeed) {
 		// Wallet is not encrypted, return a lockScreen that initializes a new wallet.
 		lockscreenContents = (
 			<UninitializedWalletDialog />

--- a/plugins/Wallet/js/components/uninitializedwalletdialog.js
+++ b/plugins/Wallet/js/components/uninitializedwalletdialog.js
@@ -49,6 +49,7 @@ const UninitializedWalletDialog = ({initializingSeed, useCustomPassphrase, showI
 UninitializedWalletDialog.propTypes = {
 	useCustomPassphrase: PropTypes.bool.isRequired,
 	showNewWalletForm: PropTypes.bool.isRequired,
+	initializingSeed: PropTypes.bool.isRequired,
 }
 
 export default UninitializedWalletDialog

--- a/plugins/Wallet/js/containers/lockscreen.js
+++ b/plugins/Wallet/js/containers/lockscreen.js
@@ -5,6 +5,7 @@ const mapStateToProps = (state) => ({
 	unlocked: state.wallet.get('unlocked'),
 	unlocking: state.wallet.get('unlocking'),
 	encrypted: state.wallet.get('encrypted'),
+	initializingSeed: state.wallet.get('initializingSeed'),
 })
 
 const LockScreen = connect(mapStateToProps)(LockScreenView)

--- a/test/wallet/lockscreen.component.js
+++ b/test/wallet/lockscreen.component.js
@@ -6,10 +6,10 @@ import LockScreen from '../../plugins/Wallet/js/components/lockscreen.js'
 import PasswordPrompt from '../../plugins/Wallet/js/containers/passwordprompt.js'
 import UninitializedWalletDialog from '../../plugins/Wallet/js/containers/uninitializedwalletdialog.js'
 
-const lockedEncryptedScreen = shallow(<LockScreen unlocked={false} encrypted unlocking={false} />)
-const lockedUnencryptedScreen = shallow(<LockScreen unlocked={false} encrypted={false} unlocking={false} />)
-const unlockedEncryptedScreen = shallow(<LockScreen unlocked encrypted unlocking={false} />)
-
+const lockedEncryptedScreen = shallow(<LockScreen unlocked={false} encrypted unlocking={false} initializingSeed={false} />)
+const lockedUnencryptedScreen = shallow(<LockScreen unlocked={false} encrypted={false} unlocking={false} initializingSeed={false} />)
+const unlockedEncryptedScreen = shallow(<LockScreen unlocked encrypted unlocking={false} initializingSeed={false} />)
+const lockedEncryptedInitializingScreen = shallow(<LockScreen unlocked={false} encrypted unlocking={false} initializingSeed />)
 describe('wallet lock screen component', () => {
 	it('renders an empty div if the wallet is unlocked and encrypted and not unlocking', () => {
 		expect(unlockedEncryptedScreen.equals(<div />)).to.be.true
@@ -19,6 +19,10 @@ describe('wallet lock screen component', () => {
 	})
 	it('renders a new wallet button if the wallet is locked but not encrypted or unlocking', () => {
 		expect(lockedUnencryptedScreen.contains(<UninitializedWalletDialog />)).to.be.true
+	})
+	it('renders an uninitialzedwalletdialog if the wallet is initializng the seed', () => {
+		expect(lockedEncryptedInitializingScreen.contains(<PasswordPrompt />)).to.be.false
+		expect(lockedEncryptedInitializingScreen.contains(<UninitializedWalletDialog />)).to.be.true
 	})
 })
 /* eslint-enable no-unused-expressions */


### PR DESCRIPTION
This fixes the issue where users could see a lockscreen and attempt to unlock during seed initialization.