### PR TITLE
Use babel preset env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,11 @@
 {
-  "presets": ["es2015", "react", "stage-3"]
+  "presets": [
+    ["env", {
+      "targets": {
+        "electron": 1.6
+      }
+    }],
+    "react",
+    "stage-3"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "devDependencies": {
     "babel-core": "^6.24.0",
     "babel-eslint": "^6.1.2",
+    "babel-preset-env": "^1.4.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-3": "^6.5.0",
     "babel-register": "^6.24.0",
     "babel-runtime": "^6.23.0",
     "chai": "^3.5.0",
@@ -31,10 +34,6 @@
   "dependencies": {
     "babel-loader": "^6.2.4",
     "babel-polyfill": "^6.9.1",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-es2016": "^6.0.11",
-    "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-3": "^6.5.0",
     "bignumber.js": "^2.1.3",
     "electron": "^1.6.7",
     "graceful-fs": "^4.1.11",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
 	},
 	resolve: {
 		root: path.resolve('./node_modules')
-	}, 
+	},
 	resolveLoader: {
 		root: path.resolve('./node_modules'),
 	},
@@ -44,17 +44,14 @@ module.exports = {
 			{
 				test: /\.json$/,
 				loader: 'json-loader',
-			}
+			},
 		],
 		loaders: [
 			{
 				test: /\.js?$/,
 				loader: 'babel',
 				exclude: /node_modules/,
-				query: {
-					presets: ['react', 'es2015', 'stage-3']
-				}
-			}
-		]
-	}
+			},
+		],
+	},
 }


### PR DESCRIPTION
It is the recommended preset to use currently. It will only transpile what is needed to make it work with the version of electron we use, lowering transpile time and improving performances.

Also remove the duplicate babel-loader query in webpack since we already use a .babelrc which is the recommended way to configure babel.

Moves babel-preset react and stage-3 to devDependencies.