### PR TITLE
no declarations inside switch cases

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
 		"eqeqeq": 2,
 		"global-require": 2,
 		"jsx-quotes": 2,
+		"no-case-declarations": 2,
 		"no-cond-assign": 2,
 		"no-dupe-args": 2,
 		"no-dupe-keys": 2,

--- a/plugins/Files/js/reducers/files.js
+++ b/plugins/Files/js/reducers/files.js
@@ -40,7 +40,7 @@ export default function filesReducer(state = initialState, action) {
 		return state.set('unreadDownloads', state.get('unreadDownloads').add(action.file.siapath))
 	case constants.UPLOAD_FILE:
 		return state.set('unreadUploads', state.get('unreadUploads').add(action.siapath))
-	case constants.RECEIVE_FILES:
+	case constants.RECEIVE_FILES: {
 		const workingDirectoryFiles = ls(action.files, state.get('path'))
 		const workingDirectorySiapaths = workingDirectoryFiles.map((file) => file.siapath)
 		// filter out selected files that are no longer in the working directory
@@ -48,15 +48,17 @@ export default function filesReducer(state = initialState, action) {
 		return state.set('files', action.files)
 		            .set('workingDirectoryFiles', workingDirectoryFiles)
 		            .set('selected', selected)
+	}
 	case constants.SET_ALLOWANCE:
 		return state.set('allowance', action.funds)
 		            .set('settingAllowance', true)
 	case constants.CLEAR_DOWNLOADS:
 		return state.set('showDownloadsSince', Date.now())
-	case constants.SET_SEARCH_TEXT:
+	case constants.SET_SEARCH_TEXT: {
 		const results = searchFiles(state.get('workingDirectoryFiles'), action.text, state.get('path'))
 		return state.set('searchResults', results)
 		            .set('searchText', action.text)
+	}
 	case constants.SET_PATH:
 		return state.set('path', action.path)
 		            .set('selected', OrderedSet())

--- a/plugins/Terminal/js/components/walletpasswordprompt.js
+++ b/plugins/Terminal/js/components/walletpasswordprompt.js
@@ -16,6 +16,8 @@ export default class WalletPasswordPrompt extends React.Component {
 		const handleTextInput = (e) => this.props.actions.setWalletPassword(e.target.value)
 		const handleKeyboardPress = (e) => {
 			if (e.keyCode === 13) {
+				const siac = httpCommand(this.props.currentCommand, this.props.actions, this.props.commandHistory.size)
+				let options
 				switch ( commandType(this.props.currentCommand, constants.specialCommands) ) {
 				case constants.WALLET_SEED:
 					this.props.actions.showSeedPrompt()
@@ -24,7 +26,7 @@ export default class WalletPasswordPrompt extends React.Component {
 				case constants.WALLET_033X:
 					// Logic for WALLET_033X and WALLET_SIAG is almost identical
 					// use the case fall through to reuse the logic.
-					let options = {
+					options = {
 						'source': getArgumentString(this.props.currentCommand, constants.specialCommands[constants.WALLET_033X]),
 						'encryptionpassword': this.props.walletPassword,
 					}
@@ -36,7 +38,6 @@ export default class WalletPasswordPrompt extends React.Component {
 					}
 
 					//Grab input, spawn process, and write options.
-					let siac = httpCommand(this.props.currentCommand, this.props.actions, this.props.commandHistory.size)
 					siac.write(querystring.stringify(options))
 					siac.end()
 					this.props.actions.setWalletPassword('')
@@ -44,7 +45,6 @@ export default class WalletPasswordPrompt extends React.Component {
 
 				default:
 					//Grab input, spawn process, and write password.
-					siac = httpCommand(this.props.currentCommand, this.props.actions, this.props.commandHistory.size)
 					siac.write(querystring.stringify({ 'encryptionpassword': this.props.walletPassword }))
 					siac.end()
 					this.props.actions.setWalletPassword('')

--- a/plugins/Terminal/js/reducers/commandline.js
+++ b/plugins/Terminal/js/reducers/commandline.js
@@ -21,9 +21,9 @@ export default function commandLineReducer(state = initialState, action) {
 			.set('commandIndex', 0).set('currentCommand', '').set('commandRunning', true)
 
 
-	case constants.UPDATE_COMMAND:
+	case constants.UPDATE_COMMAND: {
 		//Updates output of command given by command name and id.
-		let commandArray = state.get('commandHistory').findLastEntry(
+		const commandArray = state.get('commandHistory').findLastEntry(
 				(val) => (val.get('command') === action.command && val.get('id') === action.id)
 			)
 
@@ -31,12 +31,13 @@ export default function commandLineReducer(state = initialState, action) {
 			return state
 		}
 
-		let [commandIdx, newCommand] = commandArray
-		newCommand = newCommand.set('result', newCommand.get('result') + action.dataChunk)
+		const [commandIdx, command] = commandArray
+		const newCommand = command.set('result', command.get('result') + action.dataChunk)
 		return state.set('commandHistory', state.get('commandHistory').set(commandIdx, newCommand))
+	}
 
-	case constants.END_COMMAND:
-		commandArray = state.get('commandHistory').findLastEntry(
+	case constants.END_COMMAND: {
+		const commandArray = state.get('commandHistory').findLastEntry(
 				(val) => (val.get('command') === action.command && val.get('id') === action.id)
 			)
 
@@ -44,19 +45,21 @@ export default function commandLineReducer(state = initialState, action) {
 			return state
 		}
 
-		[commandIdx, newCommand] = commandArray
-		newCommand = newCommand.set('stat', 'done')
+		const [commandIdx, command] = commandArray
+		const newCommand = command.set('stat', 'done')
 		return state.set('commandHistory', state.get('commandHistory').set(commandIdx, newCommand)).set('commandRunning', false)
+	}
 
-	case constants.LOAD_PREV_COMMAND:
-		let newCommandIndex = Math.min(state.get('commandIndex')+1, state.get('commandHistory').size)
+	case constants.LOAD_PREV_COMMAND: {
+		const newCommandIndex = Math.min(state.get('commandIndex')+1, state.get('commandHistory').size)
 		return state.set('commandIndex', newCommandIndex).set('currentCommand',
 			state.get('commandHistory').get(
 				Math.min( state.get('commandHistory').size-newCommandIndex, state.get('commandHistory').size-1)
 			).get('command'))
+	}
 
-	case constants.LOAD_NEXT_COMMAND:
-		newCommandIndex = Math.max(state.get('commandIndex')-1, 0)
+	case constants.LOAD_NEXT_COMMAND: {
+		const newCommandIndex = Math.max(state.get('commandIndex')-1, 0)
 		if (newCommandIndex) {
 			return state.set('commandIndex', newCommandIndex).set('currentCommand',
 					state.get('commandHistory').get(
@@ -66,6 +69,7 @@ export default function commandLineReducer(state = initialState, action) {
 		} else {
 			return state.set('commandIndex', newCommandIndex).set('currentCommand', '')
 		}
+	}
 
 	case constants.SET_CURRENT_COMMAND:
 		return state.set('currentCommand', action.command)

--- a/plugins/Terminal/js/utils/helpers.js
+++ b/plugins/Terminal/js/utils/helpers.js
@@ -273,9 +273,8 @@ export const commandInputHelper = function(e, actions, currentCommand, showComma
 			break
 
 		case constants.HELP: //help
-			const text = 'help'
-		case constants.HELP_QMARK: //?
-			const newText = text || '?'
+		case constants.HELP_QMARK: {
+			const newText = 'help'
 			if (showCommandOverview) {
 				actions.hideCommandOverview()
 			} else {
@@ -287,7 +286,7 @@ export const commandInputHelper = function(e, actions, currentCommand, showComma
 			actions.addCommand(newCommand)
 			actions.endCommand(newCommand.get('command'), newCommand.get('id'))
 			break
-
+		}
 		default:
 			break
 		}


### PR DESCRIPTION
This PR fixes undefined behavior in the terminal plugin caused by declaring variables inside a `switch case:`. Doing this is hard to read and often leads to unexpected behavior, since all variables declared inside a `switch` have the same scope, and reducers may return inside of a case. Previously the terminal plugin's reducer was only working because of undefined behavior in the babel compiler.

I added a `no-case-declarations` rule to eslint and fixed up the terminal plugin, using `const` and a new block scope for each case.