### PR TITLE
Add autoprefixer.

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,1 @@
+electron 1.6

--- a/css/general.css
+++ b/css/general.css
@@ -29,20 +29,20 @@ html,body {
 	font-weight: 300;
 	font-size: 18px;
 
-	-webkit-user-select: none;
+	user-select: none;
 }
 .pure-g [class*="pure-u"] {
 	font-family: 'Roboto Condensed', sans-serif;
 	font-weight: 300;
 }
-::-webkit-scrollbar { 
-	display: none; 
+::scrollbar {
+	display: none;
 }
 .body {
 	position: relative;
 
-	height: -webkit-calc(100% - 80px);
-	-webkit-box-sizing:border-box;
+	height: calc(100% - 80px);
+	box-sizing:border-box;
 }
 
 /* UI Header */
@@ -113,7 +113,7 @@ html,body {
 	z-index: 5;
 	height: 100%;
 
-	-webkit-box-sizing:border-box;
+	box-sizing:border-box;
 	border-left: 0 solid #F5F5F5;
 	border-right: 1px solid #B5B5B5;
 }
@@ -125,8 +125,8 @@ html,body {
 	height: 60px;
 
 	transition: all .25s;
-	-webkit-animation: fadein .4s;
-	-webkit-box-sizing:border-box;
+	animation: fadein .4s;
+	box-sizing:border-box;
 
 	color: #606060;
 }
@@ -145,7 +145,7 @@ html,body {
 	color: #F5F5F5;
 }
 .button.current .icon, .button:hover .icon {
-	-webkit-filter: invert(100%);
+	filter: invert(100%);
 }
 @keyframes fadeout {
 	from { opacity: default; }
@@ -167,7 +167,7 @@ html,body {
 /* Mainbar */
 #mainbar {
 	transition: all .25s;
-	-webkit-animation: ease-in fadein 1.4s;
+	animation: ease-in fadein 1.4s;
 	flex-grow: 1;
 	height: 100%;
 	background-color: #ffffff;
@@ -229,7 +229,7 @@ html,body {
 	box-shadow: 0 0 16px 0 rgba(0, 0, 0, 0.25);
 	overflow-x: hidden;
 	overflow-y: hidden;
-	-webkit-transition: box-shadow 2s;
+	transition: box-shadow 2s;
 	transition: box-shadow 0.5s;
 }
 .notification .icon {

--- a/css/plugin-standard.css
+++ b/css/plugin-standard.css
@@ -114,10 +114,10 @@ select:hover {
 	font-size: 26px;
 	position: relative;
 	width: 100%;
-	-webkit-animation: fadein 0.5s;
+	animation: fadein 0.5s;
 }
 .button {
-	-webkit-user-select: none;
+	user-select: none;
 }
 .button:hover {
 	color: #4a4a4a;

--- a/doc/Technologies.md
+++ b/doc/Technologies.md
@@ -1,7 +1,7 @@
 # Technologies
 
 We use three major tools in this application and they follow this hierarchy:
-Javascript -> Node/NPM -> Electron. 
+Javascript -> Node/NPM -> Electron.
 
 ### Javascript
 
@@ -33,16 +33,15 @@ tool](http://blog.keithcirkel.co.uk/how-to-use-npm-as-a-build-tool/)
 ### [Electron](http://electron.atom.io/)
 
 It's the core set of libararies that power the Atom text editor and is useful
-for creating cross-platform desktop applications. 
+for creating cross-platform desktop applications.
 
 Making this a desktop application instead of a webapp gives us libraries to
 access filepaths and other OS resources (via Node libraries) that a webapp
-would be limited from. 
+would be limited from.
 
 The code does not have to adhere to compatibility for all browsers (looking
 at you, Internet Explorer) because electron is run on chromium. This extends
-from JS to CSS (with the use of -webkit- rules when applicable).
+from JS to CSS.
 
 We do occasionally use ES2015 and ES2016 conventions and syntax in the code
 base with no worries for the same reason
-

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "A UI application for interfacing with Sia",
   "license": "MIT",
   "devDependencies": {
+    "autoprefixer": "^7.0.1",
     "babel-core": "^6.24.0",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.0.0",
@@ -26,6 +27,7 @@
     "glob": "^7.1.1",
     "jsdom": "^9.12.0",
     "mocha": "^3.2.0",
+    "postcss-loader": "^2.0.5",
     "prop-types": "^15.5.10",
     "proxyquire": "^1.7.11",
     "ps-tree": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-runtime": "^6.23.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
+    "cssnano": "^3.10.0",
     "enzyme": "^2.8.0",
     "eslint": "^3.18.0",
     "eslint-plugin-babel": "^4.1.1",

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -303,7 +303,7 @@ div[tabindex="1"]:focus {
 	background-color: #C5C5C5;
 	margin: 0;
 	cursor: default;
-	-webkit-user-select: none;
+	user-select: none;
 	font-size: 14px;
 }
 .file-list ul {

--- a/plugins/Hosting/css/hosting.css
+++ b/plugins/Hosting/css/hosting.css
@@ -107,7 +107,7 @@
 	top: 50%;
 	left: 50%;
 	transform: translate(-50%, -50%);
-	-webkit-animation: fadein 0.5s;
+	animation: fadein 0.5s;
 	background-color: #ffffff;
 	z-index: 2;
 	border: solid 1px #c5c5c5;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,8 @@ const webpack = require('webpack')
 const path = require('path')
 const glob = require('glob')
 const version = require('./package.json').version
+const autoprefixer = require('autoprefixer')
+const cssnano = require('cssnano')
 
 function isVendor({ resource }) {
 	return resource &&
@@ -42,6 +44,21 @@ const common = {
 			{
 				test: /\.js?$/,
 				use: 'babel-loader',
+				exclude: /node_modules/,
+			},
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: 'postcss-loader',
+						options: {
+							plugins: () => [
+								autoprefixer(),
+								cssnano({ autoprefixer: false }),
+							],
+						},
+					},
+				],
 				exclude: /node_modules/,
 			},
 		],


### PR DESCRIPTION
Remove vendor prefixes and use a browserlist to state which target we support.
Soon babel-preset-env will support the browserlist file too so we can simplify the configuration further.