### PR TITLE
change default API address to 127.0.0.1 instead of localhost

### DIFF
--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -13,7 +13,7 @@ const defaultConfig = {
 		rpcaddr: ':9981',
 		hostaddr: ':9982',
 		detached: false,
-		address: 'localhost:9980',
+		address: '127.0.0.1:9980',
 	},
 	closeToTray: process.platform === 'win32' || process.platform === 'darwin' ? true : false,
 	width:	   1024,


### PR DESCRIPTION
using `localhost` as the API address can cause a massive performance hit on some systems (5-15+ seconds per request), enough for Sia-UI to think that siad has crashed. This is caused by the fact that the api, when bound to `localhost`, only listens on IPv4 (127.0.0.1), but during the lookup the OS tries IPV6 first and times out.

This is the likely explanation for when the UI reports a crash but does not show a crash log, eg: https://github.com/NebulousLabs/Sia/issues/1794.