### PR TITLE
handle `save()` exception in config.json

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: "{build}"
  
 platform: x64
 environment:
-  nodejs_version: "6.9.0"
+  nodejs_version: "6.9.2"
 
 install:
   - ps: wget https://github.com/NebulousLabs/Sia/releases/download/v1.0.3/Sia-v1.0.3-windows-amd64.zip -O Sia-v1.0.3-windows-amd64.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,5 @@ install:
   - rename Sia-v1.0.3-windows-amd64 Sia
   - npm install
 
-test_script:
-  - npm test
 
 build: off

--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -73,7 +73,11 @@ export default function configManager(filepath) {
 	config.defaultSiadPath = defaultSiadPath
 
 	// Save to disk immediately when loaded
-	config.save()
+	try {
+		config.save()
+	} catch (err) {
+		console.error("couldnt save config.json: " + err.toString())
+	}
 
 	// Return the config object with the above 3 member functions
 	return config

--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -76,7 +76,7 @@ export default function configManager(filepath) {
 	try {
 		config.save()
 	} catch (err) {
-		console.error("couldnt save config.json: " + err.toString())
+		console.error('couldnt save config.json: ' + err.toString())
 	}
 
 	// Return the config object with the above 3 member functions

--- a/test/config.unit.js
+++ b/test/config.unit.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import proxyquire from 'proxyquire'
+
+const mock = {
+	'electron': {
+		'app': {
+			getPath: () => './',
+		},
+		'@noCallThru': true,
+	},
+}
+const loadConfig = proxyquire('../js/mainjs/config.js', mock).default
+
+describe('config.js', () => {
+	afterEach(() => {
+		try {
+			fs.unlinkSync('test.json')
+		} catch (err) {
+			console.error('error cleaning up test: ', err.toString())
+		}
+	})
+	it('loads the default config successfully when an invalid path is given', () => {
+		loadConfig('/invalid/path')
+	})
+	it('saves and loads the config successfully when a valid path is given', () => {
+		const config = loadConfig('test.json')
+		config.save()
+		const config2 = loadConfig('test.json')
+		expect(config2).to.deep.equal(config)
+	})
+})
+
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,8 @@ const path = require('path')
 const glob = require('glob')
 const version = require('./package.json').version
 
-function isVendor({ resource }) {
+function isVendor(args) {
+	const resource = args.resource
 	return resource &&
 	resource.indexOf('node_modules') >= 0 &&
 	resource.match(/\.(js|json)$/)


### PR DESCRIPTION
This could cause an exception to thrown when Sia-UI starts, since `config.js` automatically attempts to save when it is first opened and the UI's data directory may not have been created yet.

I also added testing for `config.js`.