### PR TITLE
change wording to make change password prompt clearer

### DIFF
--- a/plugins/Wallet/js/components/changepassworddialog.js
+++ b/plugins/Wallet/js/components/changepassworddialog.js
@@ -16,7 +16,7 @@ const ChangePasswordDialog = ({changePasswordError, actions}) => {
 	}
 
 	return (
-		<div onClick={handleCancelClick} className="modal">
+		<div className="modal">
 			<form className="change-password-form" onSubmit={handleChangePasswordClick}>
 				<h3> Enter your current password, and the new password you wish to replace it with. </h3>
 				<input className="currentpassword-input" type="password" placeholder="Current password" name="currentpassword" autoFocus />
@@ -24,7 +24,7 @@ const ChangePasswordDialog = ({changePasswordError, actions}) => {
 				<input className="newpassword-again-input" type="password" placeholder="New password again" name="newpassword-again" />
 				<div className="change-password-buttons">
 					<button type="submit">Change Password</button>
-					<button className="change-password-cancel" onClick={handleCancelClick}>Cancel</button>
+					<button className="change-password-cancel" onClick={handleCancelClick}>Done</button>
 				</div>
 				<div className="change-password-error">{changePasswordError}</div>
 			</form>

--- a/test/wallet.integration.js
+++ b/test/wallet.integration.js
@@ -138,11 +138,6 @@ describe('wallet change password functionality', () => {
 		expect(walletComponent.find('ChangePasswordDialog')).to.have.length(1)
 		expect(walletComponent.find('.change-password-error').first().text()).to.equal('')
 	})
-	it('hides when the background is clicked', async () => {
-		walletComponent.find('.modal').simulate('click')
-		await sleep(10)
-		expect(walletComponent.find('ChangePasswordDialog')).to.have.length(0)
-	})
 })
 
 describe('wallet creation', () => {


### PR DESCRIPTION
Previously the wording for the button that dismisses the Change Password dialog was 'Cancel'. Now it's 'Done', which is less confusing given the behavior of the change password dialog. Clicking the background also no longer hides the dialog.