### PR TITLE
fix config.json upgrading issue

### DIFF
--- a/js/mainjs/config.js
+++ b/js/mainjs/config.js
@@ -1,6 +1,8 @@
 import fs from 'graceful-fs'
 import Path from 'path'
 import { app } from 'electron'
+import { version } from '../../package.json'
+import semver from 'semver'
 
 const defaultSiadPath = Path.join(__dirname, '../Sia/' + (process.platform === 'win32' ? 'siad.exe' : 'siad'))
 
@@ -20,6 +22,7 @@ const defaultConfig = {
 	height:	  768,
 	x:		   0,
 	y:		   0,
+	version: version,
 }
 
 /**
@@ -34,6 +37,15 @@ export default function configManager(filepath) {
 		config = JSON.parse(data)
 	} catch (err) {
 		config = defaultConfig
+	}
+
+	// always use the default siad path after an upgrade
+	if (typeof config.version === 'undefined') {
+		config.version = version
+	}
+	if (semver.lt(config.version, version)) {
+		config.version = version
+		config.siad.path = defaultSiadPath
 	}
 
 	// fill out default values if config is incomplete

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-redux": "^5.0.4",
     "redux": "^3.5.2",
     "redux-saga": "^0.15.3",
+    "semver": "^5.3.0",
     "sia.js": "^0.4.1"
   },
   "scripts": {

--- a/test/config.unit.js
+++ b/test/config.unit.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import fs from 'fs'
 import proxyquire from 'proxyquire'
+import { version } from '../package.json'
 
 const mock = {
 	'electron': {
@@ -28,6 +29,20 @@ describe('config.js', () => {
 		config.save()
 		const config2 = loadConfig('test.json')
 		expect(config2).to.deep.equal(config)
+	})
+	it('sets the default siad path if the config version is outdated', () => {
+		const config = loadConfig('test.json')
+		const defaultSiadPath = config.siad.path
+		config.version = '1.2.0'
+		config.siad.path = '/test/siad/path'
+		config.save()
+		const config2 = loadConfig('test.json')
+		expect(config2.siad.path).to.equal(defaultSiadPath)
+		expect(config2.version).to.equal(version)
+		config2.siad.path = '/test/new/path'
+		config2.save()
+		const config3 = loadConfig('test.json')
+		expect(config3.siad.path).to.equal('/test/new/path')
 	})
 })
 


### PR DESCRIPTION
This PR updates `config.json` by adding a version field. If this version doesn't exist, or is less than the current UI version, the `siad` specified in `config.json` will be overwritten to Sia-UI's new Siad. This is required since we moved `config.json` to the data directory, where it is reused across upgrades.

