### PR TITLE
optimize file parsing, fix directory navigation bug

### DIFF
--- a/plugins/Files/js/components/filelist.js
+++ b/plugins/Files/js/components/filelist.js
@@ -21,7 +21,8 @@ const FileList = ({files, selected, searchResults, path, showSearchField, action
 		if (pathComponents.length < 2) {
 			actions.setPath('')
 		} else {
-			actions.setPath(pathComponents[pathComponents.length-2] + '/')
+			pathComponents.pop()
+			actions.setPath(pathComponents.join('/'))
 		}
 	}
 

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -106,7 +106,11 @@ export const ls = (files, path) => {
 		if (relativePath.indexOf('/') !== -1) {
 			type = 'directory'
 			filename = relativePath.split('/')[0]
-
+		}
+		if (parsedFiles.has(filename) && parsedFiles.get(filename).type === type) {
+			return
+		}
+		if (type === 'directory') {
 			// directories cannot be named '..'.
 			if (filename === '..') {
 				return
@@ -118,9 +122,6 @@ export const ls = (files, path) => {
 			filesize = readableFilesize(totalFilesize)
 			redundancy = minRedundancy(subfiles)
 			uploadprogress = minUpload(subfiles)
-		}
-		if (parsedFiles.has(filename) && parsedFiles.get(filename).type === type) {
-			return
 		}
 		parsedFiles = parsedFiles.set(filename, {
 			size: filesize,

--- a/test/files/filelist.component.js
+++ b/test/files/filelist.component.js
@@ -79,11 +79,15 @@ describe('file list', () => {
 	it('navigates directories', () => {
 		let filelist = mount(<FileList files={testFiles} selected={OrderedSet()} showSearchField={false} path="test1/test2/" actions={testActions} />)
 		filelist.find('.back-button').first().simulate('click')
-		expect(testActions.setPath.calledWith('test1/')).to.equal(true)
+		expect(testActions.setPath.calledWith('test1')).to.equal(true)
 
 		filelist = mount(<FileList files={testFiles} showSearchField={false} selected={OrderedSet()} path="test1/" actions={testActions} />)
 		filelist.find('.back-button').first().simulate('click')
 		expect(testActions.setPath.calledWith('')).to.equal(true)
+
+		filelist = mount(<FileList files={testFiles} showSearchField={false} selected={OrderedSet()} path="test1/test2/test3/" actions={testActions} />)
+		filelist.find('.back-button').first().simulate('click')
+		expect(testActions.setPath.calledWith('test1/test2')).to.equal(true)
 
 		const renderedDirectories = filelist.find('File [type="directory"]')
 		renderedDirectories.forEach((directory) => {


### PR DESCRIPTION
This PR optimizes the UI's file parsing, fixing a case where the entire file tree would be traversed unnecessarily `n` amount of times per directory. It also fixes a bug where the back button would not work correctly with file paths deeper than 3 directories deep. I added a regression test for the bug, and profiled the file parsing changes manually. This should help users who experience large slowdowns with lots of uploaded files.