### PR TITLE
Update checker

### DIFF
--- a/plugins/About/css/about.css
+++ b/plugins/About/css/about.css
@@ -20,3 +20,6 @@
 	display: inline-block;
 	color: #4a4a4a;
 }
+button {
+    color: #4a4a4a;
+}

--- a/plugins/About/index.html
+++ b/plugins/About/index.html
@@ -19,7 +19,7 @@
 
 			<!-- Version Info -->
 			<div class='about'>
-			 	Sia UI version:
+				Sia UI version:
 				<div class='version'>
 					<span id='uiversion'></span>
 				</div>
@@ -28,6 +28,21 @@
 				Sia version:
 				<div class='version'>
 					<span id='siaversion'></span>
+				</div>
+			</div>
+			<div class='about'>
+				<button id='updatecheck'>Check for Update</button>
+			</div>
+			<div id='nonew' class='about' style='display:none'>
+				You are on the latest version.
+			</div>
+			<div id='yesnew' class='about' style='display:none'>
+				A new version is available:
+				<span id='newversion'></span>
+				<div class='version'>
+					<a href='' id='downloadlink'>
+						<button>Download</button>
+					</a>
 				</div>
 			</div>
 		</div>

--- a/plugins/About/js/index.js
+++ b/plugins/About/js/index.js
@@ -1,6 +1,5 @@
 'use strict'
 import { platform } from 'os'
-import { format } from 'util'
 
 // Set UI version via package.json.
 document.getElementById('uiversion').innerHTML = VERSION
@@ -15,13 +14,13 @@ SiaAPI.call('/daemon/version', (err, result) => {
 	}
 })
 
-function genDownloadLink(version, platform) {
-	let plat = platform
+function genDownloadLink(version, thePlatform) {
+	let plat = thePlatform
 	if (plat === 'darwin') {
 		plat = 'osx'
 	}
 
-	return format('https://github.com/NebulousLabs/Sia-UI/releases/download/v%s/Sia-UI-v%s-%s-x64.zip', version, version, plat)
+	return `https://github.com/NebulousLabs/Sia-UI/releases/download/v${version}/Sia-UI-v${version}-${plat}-x64.zip`
 }
 
 function updateCheck() {

--- a/plugins/About/js/index.js
+++ b/plugins/About/js/index.js
@@ -1,4 +1,6 @@
 'use strict'
+const os = require('os')
+const util = require('util')
 
 // Set UI version via package.json.
 document.getElementById('uiversion').innerHTML = VERSION
@@ -13,3 +15,30 @@ SiaAPI.call('/daemon/version', (err, result) => {
 	}
 })
 
+function genDownloadLink(version, platform) {
+	let plat = platform
+	if (plat === 'darwin') {
+		plat = 'osx'
+	}
+
+	return util.format('https://github.com/NebulousLabs/Sia-UI/releases/download/v%s/Sia-UI-v%s-%s-x64.zip', version, version, plat)
+}
+
+function updateCheck() {
+	SiaAPI.call('/daemon/update', (err, result) => {
+		if (err) {
+			SiaAPI.showError('Error', err.toString())
+			ipcRenderer.sendToHost('notification', err.toString(), 'error')
+		} else if (result.available) {
+			document.getElementById('newversion').innerHTML = result.version
+			document.getElementById('downloadlink').href = genDownloadLink(result.version, os.platform())
+			document.getElementById('nonew').style.display = 'none'
+			document.getElementById('yesnew').style.display = 'block'
+		} else {
+			document.getElementById('nonew').style.display = 'block'
+			document.getElementById('yesnew').style.display = 'none'
+		}
+	})
+}
+
+document.getElementById('updatecheck').onclick = updateCheck

--- a/plugins/About/js/index.js
+++ b/plugins/About/js/index.js
@@ -8,7 +8,6 @@ document.getElementById('uiversion').innerHTML = VERSION
 SiaAPI.call('/daemon/version', (err, result) => {
 	if (err) {
 		SiaAPI.showError('Error', err.toString())
-		ipcRenderer.sendToHost('notification', err.toString(), 'error')
 	} else {
 		document.getElementById('siaversion').innerHTML = result.version
 	}
@@ -27,7 +26,6 @@ function updateCheck() {
 	SiaAPI.call('/daemon/update', (err, result) => {
 		if (err) {
 			SiaAPI.showError('Error', err.toString())
-			ipcRenderer.sendToHost('notification', err.toString(), 'error')
 		} else if (result.available) {
 			document.getElementById('newversion').innerHTML = result.version
 			document.getElementById('downloadlink').href = genDownloadLink(result.version, platform())

--- a/plugins/About/js/index.js
+++ b/plugins/About/js/index.js
@@ -1,6 +1,6 @@
 'use strict'
-const os = require('os')
-const util = require('util')
+import { platform } from 'os'
+import { format } from 'util'
 
 // Set UI version via package.json.
 document.getElementById('uiversion').innerHTML = VERSION
@@ -21,7 +21,7 @@ function genDownloadLink(version, platform) {
 		plat = 'osx'
 	}
 
-	return util.format('https://github.com/NebulousLabs/Sia-UI/releases/download/v%s/Sia-UI-v%s-%s-x64.zip', version, version, plat)
+	return format('https://github.com/NebulousLabs/Sia-UI/releases/download/v%s/Sia-UI-v%s-%s-x64.zip', version, version, plat)
 }
 
 function updateCheck() {
@@ -31,7 +31,7 @@ function updateCheck() {
 			ipcRenderer.sendToHost('notification', err.toString(), 'error')
 		} else if (result.available) {
 			document.getElementById('newversion').innerHTML = result.version
-			document.getElementById('downloadlink').href = genDownloadLink(result.version, os.platform())
+			document.getElementById('downloadlink').href = genDownloadLink(result.version, platform())
 			document.getElementById('nonew').style.display = 'none'
 			document.getElementById('yesnew').style.display = 'block'
 		} else {


### PR DESCRIPTION
Added update checker button to `About` plugin. Uses built in `siad` update check then forms a download link with the version given and value returned from `os.platform()`.

Initial state:
![deepinscreenshot_select-area_20170710162940](https://user-images.githubusercontent.com/729707/28044852-ab7e8866-658e-11e7-8ec9-3d825cbdfabc.png)

After checking for update:
![deepinscreenshot_20170710163012](https://user-images.githubusercontent.com/729707/28044894-de39ecbe-658e-11e7-91df-30158d23f7a5.png)

If already updated:
![deepinscreenshot_20170710163106](https://user-images.githubusercontent.com/729707/28044877-cc2ac6d8-658e-11e7-9ade-a774ccb88087.png)


