### PR TITLE
better allowance spending visualization

### DIFF
--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -273,6 +273,107 @@ div[tabindex="1"]:focus {
 }
 .files-usage-info {
 	margin-left: 15px;
+	margin-right: 15px;
+	display: flex;
+	align-items: center;
+	position: relative;
+}
+.files-usage-info > * {
+	display: inline-block;
+}
+.spending-bar {
+	height: 20px;
+	width: 300px;
+	background-color: #eee;
+	cursor: help;
+	position: relative;
+}
+.remaining-text {
+	color: #fff;
+	font-size: 12px;
+	margin-left: 5px;
+}
+
+.spending-breakdown {
+	display: none !important;
+	position: absolute;
+	top: 45px;
+	background: #808080;
+	border: 1px solid #00CBA0;
+	font-size: 18px;
+	padding: 10px 10px 10px 10px;
+	width: 300px;
+	white-space: pre-wrap;
+	z-index: 100;
+}
+
+.spending-breakdown:after, .spending-breakdown:before {
+	bottom: 100%;
+	left: 50%;
+	border: solid transparent;
+	content: " ";
+	height: 0;
+	width: 0;
+	position: absolute;
+	pointer-events: none;
+}
+
+.spending-breakdown > ul {
+	list-style: none;
+}
+
+.spending-breakdown:after {
+	border-color: rgba(82, 82, 82, 0);
+	border-bottom-color: #808080;
+	border-width: 30px;
+	margin-left: -30px;
+}
+
+.spending-breakdown:before {
+	border-color: rgba(0, 203, 160, 0);
+	border-bottom-color: #00CBA0;
+	border-width: 30px;
+	margin-left: -30px;
+}
+
+.files-usage-info:hover .spending-breakdown {
+	display: inline-block !important;
+}
+
+.spending-bar > div {
+	height: 20px;
+	display: inline-block;
+	border-right: 1px solid #fff;
+}
+.spending-bar > div:last-of-type {
+	border-right: none;
+}
+.spending-bar > .download-spending {
+	background-color: #68ffdf;
+}
+.spending-bar > .upload-spending {
+	background-color: #13f1c1;
+}
+.spending-bar > .contract-spending {
+	background-color: #0c4a3d;
+}
+.spending-bar > .storage-spending {
+	background-color: #03654f;
+}
+.allowance-spending-breakdown {
+	margin-bottom: 25px;
+}
+.contract-spending-breakdown {
+	color: #0c4a3d;
+}
+.storage-spending-breakdown {
+	color: #03654f;
+}
+.upload-spending-breakdown {
+	color: #13f1c1;
+}
+.download-spending-breakdown {
+	color: #68ffdf;
 }
 .files-toolbar .buttons div span {
 	display: block;

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -361,7 +361,10 @@ div[tabindex="1"]:focus {
 	background-color: #03654f;
 }
 .allowance-spending-breakdown {
-	margin-bottom: 25px;
+	margin-bottom: 5px;
+}
+.renew-info {
+	margin-bottom: 20px;
 }
 .contract-spending-breakdown {
 	color: #0c4a3d;

--- a/plugins/Files/js/actions/files.js
+++ b/plugins/Files/js/actions/files.js
@@ -28,9 +28,12 @@ export const receiveAllowance = (allowance) => ({
 	type: constants.RECEIVE_ALLOWANCE,
 	allowance,
 })
-export const receiveSpending = (spending) => ({
+export const receiveSpending = (downloadspending, uploadspending, storagespending, contractspending) => ({
 	type: constants.RECEIVE_SPENDING,
-	spending,
+	downloadspending,
+	uploadspending,
+	storagespending,
+	contractspending,
 })
 export const getStorageEstimate = (funds) => ({
 	type: constants.GET_STORAGE_ESTIMATE,

--- a/plugins/Files/js/actions/files.js
+++ b/plugins/Files/js/actions/files.js
@@ -28,12 +28,13 @@ export const receiveAllowance = (allowance) => ({
 	type: constants.RECEIVE_ALLOWANCE,
 	allowance,
 })
-export const receiveSpending = (downloadspending, uploadspending, storagespending, contractspending) => ({
+export const receiveSpending = (downloadspending, uploadspending, storagespending, contractspending, renewheight) => ({
 	type: constants.RECEIVE_SPENDING,
 	downloadspending,
 	uploadspending,
 	storagespending,
 	contractspending,
+	renewheight,
 })
 export const getStorageEstimate = (funds) => ({
 	type: constants.GET_STORAGE_ESTIMATE,

--- a/plugins/Files/js/components/usagestats.js
+++ b/plugins/Files/js/components/usagestats.js
@@ -1,15 +1,38 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const UsageStats = ({allowance, spending}) => (
-	<div className="files-usage-info">
-		<span> {spending} SC Spent / {allowance} SC Allocated </span>
-	</div>
-)
+// UsageStats defines the presentation component for displaying file spending.
+const UsageStats = ({allowance, downloadspending, uploadspending, storagespending, contractspending}) => {
+	const unspent = () => allowance - (downloadspending+uploadspending+storagespending+contractspending)
+	return (
+		<div className="files-usage-info">
+			<div className="spending-bar">
+				<div style={{width: (contractspending/allowance)*100+ '%'}} className="contract-spending" />
+				<div style={{width: (storagespending/allowance)*100+ '%'}} className="storage-spending" />
+				<div style={{width: (downloadspending/allowance)*100+ '%'}} className="download-spending" />
+				<div style={{width: (uploadspending/allowance)*100 + '%'}} className="upload-spending" />
+			</div>
+			<p className="remaining-text">{unspent()} SC remaining</p>
+			<div className="spending-breakdown">
+				<ul>
+					<li className="allowance-spending-breakdown"> Allowance: {allowance} SC </li>
+					<li className="contract-spending-breakdown"> Contract Spending: {contractspending} SC </li>
+					<li className="storage-spending-breakdown"> Storage Spending: {storagespending} SC </li>
+					<li className="upload-spending-breakdown"> Upload Spending: {uploadspending} SC </li>
+					<li className="download-spending-breakdown"> Download Spending: {downloadspending} SC </li>
+				</ul>
+			</div>
+		</div>
+	)
+}
 
 UsageStats.propTypes = {
-	allowance: PropTypes.string.isRequired,
-	spending: PropTypes.string.isRequired,
+	allowance: PropTypes.number.isRequired,
+	downloadspending: PropTypes.number.isRequired,
+	uploadspending: PropTypes.number.isRequired,
+	storagespending: PropTypes.number.isRequired,
+	contractspending: PropTypes.number.isRequired,
 }
 
 export default UsageStats
+

--- a/plugins/Files/js/components/usagestats.js
+++ b/plugins/Files/js/components/usagestats.js
@@ -3,7 +3,7 @@ import React from 'react'
 
 // UsageStats defines the presentation component for displaying file spending.
 const UsageStats = ({allowance, downloadspending, uploadspending, storagespending, contractspending, renewheight}) => {
-	const unspent = () => allowance - (downloadspending+uploadspending+storagespending+contractspending)
+	const unspent = allowance - (downloadspending+uploadspending+storagespending+contractspending)
 	return (
 		<div className="files-usage-info">
 			<div className="spending-bar">
@@ -12,7 +12,7 @@ const UsageStats = ({allowance, downloadspending, uploadspending, storagespendin
 				<div style={{width: (downloadspending/allowance)*100+ '%'}} className="download-spending" />
 				<div style={{width: (uploadspending/allowance)*100 + '%'}} className="upload-spending" />
 			</div>
-			<p className="remaining-text">{unspent()} SC remaining</p>
+			<p className="remaining-text">{unspent} SC remaining</p>
 			<div className="spending-breakdown">
 				<ul>
 					<li className="allowance-spending-breakdown">Allowance: {allowance} SC </li>

--- a/plugins/Files/js/components/usagestats.js
+++ b/plugins/Files/js/components/usagestats.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 // UsageStats defines the presentation component for displaying file spending.
-const UsageStats = ({allowance, downloadspending, uploadspending, storagespending, contractspending}) => {
+const UsageStats = ({allowance, downloadspending, uploadspending, storagespending, contractspending, renewheight}) => {
 	const unspent = () => allowance - (downloadspending+uploadspending+storagespending+contractspending)
 	return (
 		<div className="files-usage-info">
@@ -15,7 +15,8 @@ const UsageStats = ({allowance, downloadspending, uploadspending, storagespendin
 			<p className="remaining-text">{unspent()} SC remaining</p>
 			<div className="spending-breakdown">
 				<ul>
-					<li className="allowance-spending-breakdown"> Allowance: {allowance} SC </li>
+					<li className="allowance-spending-breakdown">Allowance: {allowance} SC </li>
+					<li className="renew-info">Renews at Block Height: {renewheight}</li>
 					<li className="contract-spending-breakdown"> Contract Spending: {contractspending} SC </li>
 					<li className="storage-spending-breakdown"> Storage Spending: {storagespending} SC </li>
 					<li className="upload-spending-breakdown"> Upload Spending: {uploadspending} SC </li>
@@ -32,6 +33,7 @@ UsageStats.propTypes = {
 	uploadspending: PropTypes.number.isRequired,
 	storagespending: PropTypes.number.isRequired,
 	contractspending: PropTypes.number.isRequired,
+	renewheight: PropTypes.number.isRequired,
 }
 
 export default UsageStats

--- a/plugins/Files/js/containers/usagestats.js
+++ b/plugins/Files/js/containers/usagestats.js
@@ -3,7 +3,10 @@ import { connect } from 'react-redux'
 
 const mapStateToProps = (state) => ({
 	allowance: state.files.get('allowance'),
-	spending: state.files.get('spending'),
+	downloadspending: state.files.get('downloadspending'),
+	uploadspending: state.files.get('uploadspending'),
+	storagespending: state.files.get('storagespending'),
+	contractspending: state.files.get('contractspending'),
 })
 
 const UsageStats = connect(mapStateToProps)(UsageStatsView)

--- a/plugins/Files/js/containers/usagestats.js
+++ b/plugins/Files/js/containers/usagestats.js
@@ -7,6 +7,7 @@ const mapStateToProps = (state) => ({
 	uploadspending: state.files.get('uploadspending'),
 	storagespending: state.files.get('storagespending'),
 	contractspending: state.files.get('contractspending'),
+	renewheight: state.files.get('renewheight'),
 })
 
 const UsageStats = connect(mapStateToProps)(UsageStatsView)

--- a/plugins/Files/js/reducers/files.js
+++ b/plugins/Files/js/reducers/files.js
@@ -27,8 +27,11 @@ const initialState = Map({
 	dragFolderTarget: '',
 	dragFileOrigin: {},
 	contractCount: 0,
-	allowance: '0',
-	spending: '0',
+	allowance: 0,
+	downloadspending: 0,
+	uploadspending: 0,
+	storagespending: 0,
+	contractspending: 0,
 	showDownloadsSince: Date.now(),
 	unreadUploads: Set(),
 	unreadDownloads: Set(),
@@ -48,7 +51,10 @@ export default function filesReducer(state = initialState, action) {
 	case constants.RECEIVE_ALLOWANCE:
 		return state.set('allowance', action.allowance)
 	case constants.RECEIVE_SPENDING:
-		return state.set('spending', action.spending)
+		return state.set('downloadspending', action.downloadspending)
+		            .set('uploadspending', action.uploadspending)
+		            .set('storagespending', action.storagespending)
+		            .set('contractspending', action.contractspending)
 	case constants.DOWNLOAD_FILE:
 		return state.set('unreadDownloads', state.get('unreadDownloads').add(action.file.siapath))
 	case constants.UPLOAD_FILE:

--- a/plugins/Files/js/reducers/files.js
+++ b/plugins/Files/js/reducers/files.js
@@ -32,6 +32,7 @@ const initialState = Map({
 	uploadspending: 0,
 	storagespending: 0,
 	contractspending: 0,
+	renewheight: 0,
 	showDownloadsSince: Date.now(),
 	unreadUploads: Set(),
 	unreadDownloads: Set(),
@@ -55,6 +56,7 @@ export default function filesReducer(state = initialState, action) {
 		            .set('uploadspending', action.uploadspending)
 		            .set('storagespending', action.storagespending)
 		            .set('contractspending', action.contractspending)
+		            .set('renewheight', action.renewheight)
 	case constants.DOWNLOAD_FILE:
 		return state.set('unreadDownloads', state.get('unreadDownloads').add(action.file.siapath))
 	case constants.UPLOAD_FILE:

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -61,16 +61,13 @@ function* getAllowanceSaga() {
 	try {
 		const response = yield siadCall('/renter')
 		const allowance = SiaAPI.hastingsToSiacoins(response.settings.allowance.funds)
+		const downloadspending = SiaAPI.hastingsToSiacoins(response.financialmetrics.downloadspending)
+		const uploadspending = SiaAPI.hastingsToSiacoins(response.financialmetrics.uploadspending)
+		const contractspending = SiaAPI.hastingsToSiacoins(response.financialmetrics.contractspending)
+		const storagespending = SiaAPI.hastingsToSiacoins(response.financialmetrics.storagespending)
 
-		// compute allowance spending. Set the spending to zero if it is negative,
-		// since negative spending is confusing to the user.
-		let spending = allowance.minus(SiaAPI.hastingsToSiacoins(response.financialmetrics.unspent))
-		if (spending.isNegative()) {
-			spending = new BigNumber(0)
-		}
-
-		yield put(actions.receiveAllowance(allowance.round(0).toString()))
-		yield put(actions.receiveSpending(spending.round(0).toString()))
+		yield put(actions.receiveAllowance(allowance.round(0).toNumber()))
+		yield put(actions.receiveSpending(downloadspending.round(2).toNumber(), uploadspending.round(2).toNumber(), storagespending.round(2).toNumber(), contractspending.round(2).toNumber()))
 	} catch (e) {
 		console.error('error getting allowance: ' + e.toString())
 	}

--- a/plugins/Files/js/sagas/files.js
+++ b/plugins/Files/js/sagas/files.js
@@ -66,8 +66,16 @@ function* getAllowanceSaga() {
 		const contractspending = SiaAPI.hastingsToSiacoins(response.financialmetrics.contractspending)
 		const storagespending = SiaAPI.hastingsToSiacoins(response.financialmetrics.storagespending)
 
+		const consensus = yield siadCall('/consensus')
+		const renewheight = (() => {
+			if (response.settings.allowance.renewwindow === 0) {
+				return 0
+			}
+			return response.settings.allowance.renewwindow + consensus.height
+		})()
+
 		yield put(actions.receiveAllowance(allowance.round(0).toNumber()))
-		yield put(actions.receiveSpending(downloadspending.round(2).toNumber(), uploadspending.round(2).toNumber(), storagespending.round(2).toNumber(), contractspending.round(2).toNumber()))
+		yield put(actions.receiveSpending(downloadspending.round(2).toNumber(), uploadspending.round(2).toNumber(), storagespending.round(2).toNumber(), contractspending.round(2).toNumber(), renewheight))
 	} catch (e) {
 		console.error('error getting allowance: ' + e.toString())
 	}

--- a/test/files/usagestats.component.js
+++ b/test/files/usagestats.component.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { expect } from 'chai'
+import UsageStats from '../../plugins/Files/js/components/usagestats.js'
+
+describe('files usage stats component', () => {
+	it('displays a spending bar with four sub-bars', () => {
+		const component = shallow(<UsageStats allowance={100} downloadspending={10} uploadspending={10} storagespending={10} contractspending={10} />)
+		expect(component.find('.spending-bar')).to.have.length(1)
+		expect(component.find('.spending-bar').children()).to.have.length(4)
+	})
+	it('renders subbars with correct width attributes', () => {
+		const component = shallow(<UsageStats allowance={100} downloadspending={6} uploadspending={5} storagespending={20} contractspending={10} />)
+		expect(component.find('.download-spending').props().style).to.have.property('width', '6%')
+		expect(component.find('.upload-spending').props().style).to.have.property('width', '5%')
+		expect(component.find('.storage-spending').props().style).to.have.property('width', '20%')
+		expect(component.find('.contract-spending').props().style).to.have.property('width', '10%')
+	})
+})


### PR DESCRIPTION
This PR improves Sia-UI's `UsageStats` component, updating it to use the renter's `financialmetrics` endpoint, and to visualize the various components of the allowance's spending. The simple `Spent / Allocated` is replaced with a segmented bar, where each spending metric (`upload`, `download`, `contract`, `storage`) is represented with a unique color and sized proportionately to its percentage of spending.

Screenshots:

![sia1](https://user-images.githubusercontent.com/8183920/29542649-8a194a94-86a9-11e7-94f1-ef0cd56db19a.png)
![sia2](https://user-images.githubusercontent.com/8183920/29542653-8d375176-86a9-11e7-9e10-f4744a9a777c.png)

