### PR TITLE
show siacoin claim balance in Wallet plugin

### DIFF
--- a/plugins/Wallet/js/actions/wallet.js
+++ b/plugins/Wallet/js/actions/wallet.js
@@ -35,11 +35,12 @@ export const createNewWallet = (password, seed) => ({
 export const getBalance = () => ({
 	type: constants.GET_BALANCE,
 })
-export const setBalance = (confirmed, unconfirmed, siafunds) => ({
+export const setBalance = (confirmed, unconfirmed, siafunds, siacoinclaimbalance) => ({
 	type: constants.SET_BALANCE,
 	confirmed,
 	unconfirmed,
 	siafunds,
+	siacoinclaimbalance,
 })
 export const getTransactions = () => ({
 	type: constants.GET_TRANSACTIONS,

--- a/plugins/Wallet/js/components/balanceinfo.js
+++ b/plugins/Wallet/js/components/balanceinfo.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const BalanceInfo = ({synced, confirmedbalance, unconfirmedbalance, siafundbalance, siacoinclaimbalance}) => (
+	<div className="balance-info">
+		<span>Confirmed Balance: {confirmedbalance} SC </span>
+		<span>Unconfirmed Delta: {unconfirmedbalance} SC </span>
+		{siafundbalance !== '0' ? (<span> Siafund Balance: {siafundbalance} SF </span>) : null}
+		{!synced ? (
+			<span style={{marginRight: '40px', color: 'rgb(255, 93, 93)'}} className="fa fa-exclamation-triangle">Your wallet is not synced, balances are not final.</span>
+		) : null
+		}
+	</div>
+)
+BalanceInfo.propTypes = {
+	synced: PropTypes.bool.isRequired,
+	confirmedbalance: PropTypes.string.isRequired,
+	unconfirmedbalance: PropTypes.string.isRequired,
+	siafundbalance: PropTypes.string.isRequired,
+	siacoinclaimbalance: PropTypes.string.isRequired,
+}
+export default BalanceInfo
+

--- a/plugins/Wallet/js/components/balanceinfo.js
+++ b/plugins/Wallet/js/components/balanceinfo.js
@@ -6,6 +6,7 @@ const BalanceInfo = ({synced, confirmedbalance, unconfirmedbalance, siafundbalan
 		<span>Confirmed Balance: {confirmedbalance} SC </span>
 		<span>Unconfirmed Delta: {unconfirmedbalance} SC </span>
 		{siafundbalance !== '0' ? (<span> Siafund Balance: {siafundbalance} SF </span>) : null}
+		{siacoinclaimbalance !== '0' ? (<span> Siacoin Claim Balance: {siacoinclaimbalance} SC </span>) : null}
 		{!synced ? (
 			<span style={{marginRight: '40px', color: 'rgb(255, 93, 93)'}} className="fa fa-exclamation-triangle">Your wallet is not synced, balances are not final.</span>
 		) : null

--- a/plugins/Wallet/js/components/wallet.js
+++ b/plugins/Wallet/js/components/wallet.js
@@ -13,21 +13,14 @@ import ChangePasswordButton from '../containers/changepasswordbutton.js'
 import ChangePasswordDialog from '../containers/changepassworddialog.js'
 import BackupButton from '../containers/backupbutton.js'
 import BackupPrompt from '../containers/backupprompt.js'
+import BalanceInfo from '../containers/balanceinfo.js'
 
-const Wallet = ({synced, showBackupPrompt, confirmedbalance, unconfirmedbalance, siafundbalance, showReceivePrompt, showChangePasswordDialog, showSendPrompt, showNewWalletDialog, showRecoveryDialog, actions }) => {
+const Wallet = ({showBackupPrompt, siafundbalance, showReceivePrompt, showChangePasswordDialog, showSendPrompt, showNewWalletDialog, showRecoveryDialog, actions }) => {
 	const onSendClick = (currencytype) => () => actions.startSendPrompt(currencytype)
 	return (
 		<div className="wallet">
 			<div className="wallet-toolbar">
-				<div className="balance-info">
-					<span>Confirmed Balance: {confirmedbalance} SC </span>
-					<span>Unconfirmed Delta: {unconfirmedbalance} SC </span>
-					{siafundbalance !== '0' ? (<span> Siafund Balance: {siafundbalance} SF </span>) : null}
-					{!synced ? (
-						<span style={{marginRight: '40px', color: 'rgb(255, 93, 93)'}} className="fa fa-exclamation-triangle">Your wallet is not synced, balances are not final.</span>
-						) : null
-					}
-				</div>
+				<BalanceInfo />
 				<BackupButton />
 				<ChangePasswordButton />
 				<LockButton />
@@ -48,9 +41,6 @@ const Wallet = ({synced, showBackupPrompt, confirmedbalance, unconfirmedbalance,
 }
 
 Wallet.propTypes = {
-	synced: PropTypes.bool.isRequired,
-	confirmedbalance: PropTypes.string.isRequired,
-	unconfirmedbalance: PropTypes.string.isRequired,
 	siafundbalance: PropTypes.string.isRequired,
 	showNewWalletDialog: PropTypes.bool,
 	showSendPrompt: PropTypes.bool,

--- a/plugins/Wallet/js/containers/balanceinfo.js
+++ b/plugins/Wallet/js/containers/balanceinfo.js
@@ -12,4 +12,4 @@ const mapDispatchToProps = () => ({
 })
 
 const BalanceInfo = connect(mapStateToProps, mapDispatchToProps)(BalanceInfoView)
-export default BalanceInfo 
+export default BalanceInfo

--- a/plugins/Wallet/js/containers/balanceinfo.js
+++ b/plugins/Wallet/js/containers/balanceinfo.js
@@ -1,0 +1,15 @@
+import BalanceInfoView from '../components/balanceinfo.js'
+import { connect } from 'react-redux'
+
+const mapStateToProps = (state) => ({
+	synced: state.wallet.get('synced'),
+	confirmedbalance: state.wallet.get('confirmedbalance'),
+	unconfirmedbalance: state.wallet.get('unconfirmedbalance'),
+	siafundbalance: state.wallet.get('siafundbalance'),
+	siacoinclaimbalance: state.wallet.get('siacoinclaimbalance'),
+})
+const mapDispatchToProps = () => ({
+})
+
+const BalanceInfo = connect(mapStateToProps, mapDispatchToProps)(BalanceInfoView)
+export default BalanceInfo 

--- a/plugins/Wallet/js/containers/wallet.js
+++ b/plugins/Wallet/js/containers/wallet.js
@@ -5,8 +5,6 @@ import { startSendPrompt } from '../actions/wallet.js'
 
 const mapStateToProps = (state) => ({
 	synced: state.wallet.get('synced'),
-	confirmedbalance: state.wallet.get('confirmedbalance'),
-	unconfirmedbalance: state.wallet.get('unconfirmedbalance'),
 	siafundbalance: state.wallet.get('siafundbalance'),
 	showReceivePrompt: state.wallet.get('showReceivePrompt'),
 	showSendPrompt: state.wallet.get('showSendPrompt'),

--- a/plugins/Wallet/js/containers/wallet.js
+++ b/plugins/Wallet/js/containers/wallet.js
@@ -4,7 +4,6 @@ import { bindActionCreators } from 'redux'
 import { startSendPrompt } from '../actions/wallet.js'
 
 const mapStateToProps = (state) => ({
-	synced: state.wallet.get('synced'),
 	siafundbalance: state.wallet.get('siafundbalance'),
 	showReceivePrompt: state.wallet.get('showReceivePrompt'),
 	showSendPrompt: state.wallet.get('showSendPrompt'),

--- a/plugins/Wallet/js/reducers/wallet.js
+++ b/plugins/Wallet/js/reducers/wallet.js
@@ -12,6 +12,7 @@ const initialState = Map({
 	confirmedbalance: '0',
 	unconfirmedbalance: '0',
 	siafundbalance: '0',
+	siacoinclaimbalance: '0',
 	transactions: List(),
 	ntransactions: 30,
 	filter: true,

--- a/plugins/Wallet/js/reducers/wallet.js
+++ b/plugins/Wallet/js/reducers/wallet.js
@@ -80,6 +80,7 @@ export default function walletReducer(state = initialState, action) {
 			.set('confirmedbalance', action.confirmed)
 			.set('unconfirmedbalance', action.unconfirmed)
 			.set('siafundbalance', action.siafunds)
+			.set('siacoinclaimbalance', action.siacoinclaimbalance)
 	case constants.SHOW_MORE_TRANSACTIONS:
 		return state.set(
 			'ntransactions',

--- a/plugins/Wallet/js/sagas/wallet.js
+++ b/plugins/Wallet/js/sagas/wallet.js
@@ -124,10 +124,11 @@ function* getBalanceSaga() {
 	try {
 		const response = yield siadCall('/wallet')
 		const confirmed = SiaAPI.hastingsToSiacoins(response.confirmedsiacoinbalance)
+		const siacoinclaimbalance = SiaAPI.hastingsToSiacoins(response.siacoinclaimbalance)
 		const unconfirmedIncoming = SiaAPI.hastingsToSiacoins(response.unconfirmedincomingsiacoins)
 		const unconfirmedOutgoing = SiaAPI.hastingsToSiacoins(response.unconfirmedoutgoingsiacoins)
 		const unconfirmed = unconfirmedIncoming.minus(unconfirmedOutgoing)
-		yield put(actions.setBalance(confirmed.round(2).toString(), unconfirmed.round(2).toString(), response.siafundbalance))
+		yield put(actions.setBalance(confirmed.round(2).toString(), unconfirmed.round(2).toString(), response.siafundbalance, siacoinclaimbalance.round(2).toString()))
 	} catch (e) {
 		console.error('error fetching balance: ' + e.toString())
 	}

--- a/test/wallet/balanceinfo.component.js
+++ b/test/wallet/balanceinfo.component.js
@@ -1,24 +1,22 @@
-/* eslint-disable no-unused-expressions */
 import React from 'react'
 import { shallow } from 'enzyme'
 import { expect } from 'chai'
 import BalanceInfo from '../../plugins/Wallet/js/components/balanceinfo.js'
 
-
 describe('wallet balance info component', () => {
 	it('renders balance info', () => {
-		const component= shallow(<BalanceInfo synced confirmedbalance="10" unconfirmedbalance="1" siafundbalance="0" />)
+		const component= shallow(<BalanceInfo synced confirmedbalance="10" unconfirmedbalance="1" siafundbalance="0" siacoinclaimbalance="0" />)
 		expect(component.find('.balance-info').children()).to.have.length(2)
 		expect(component.find('.balance-info').children().first().text()).to.contain('Confirmed Balance: 10 SC')
 		expect(component.find('.balance-info').children().last().text()).to.contain('Unconfirmed Delta: 1 SC')
 	})
 	it('renders siafund balance when it is non-zero', () => {
-		const component = shallow(<BalanceInfo synced confirmedbalance="10" unconfirmedbalance="1" siafundbalance="1" />)
+		const component = shallow(<BalanceInfo synced confirmedbalance="10" unconfirmedbalance="1" siafundbalance="1" siacoinclaimbalance="0" />)
 		expect(component.find('.balance-info').children()).to.have.length(3)
 		expect(component.find('.balance-info').children().last().text()).to.contain('Siafund Balance: 1 SF')
 	})
 	it('renders a warning when not synced', () => {
-		const component = shallow(<BalanceInfo synced={false} confirmedbalance="10" unconfirmedbalance="1" siafundbalance="0" />)
+		const component = shallow(<BalanceInfo synced={false} confirmedbalance="10" unconfirmedbalance="1" siafundbalance="0" siacoinclaimbalance="0" />)
 		expect(component.find('.balance-info').children()).to.have.length(3)
 		expect(component.find('.balance-info').children().last().text()).to.contain('Your wallet is not synced, balances are not final.')
 	})

--- a/test/wallet/balanceinfo.component.js
+++ b/test/wallet/balanceinfo.component.js
@@ -1,0 +1,25 @@
+/* eslint-disable no-unused-expressions */
+import React from 'react'
+import { shallow } from 'enzyme'
+import { expect } from 'chai'
+import BalanceInfo from '../../plugins/Wallet/js/components/balanceinfo.js'
+
+
+describe('wallet balance info component', () => {
+	it('renders balance info', () => {
+		const component= shallow(<BalanceInfo synced confirmedbalance="10" unconfirmedbalance="1" siafundbalance="0" />)
+		expect(component.find('.balance-info').children()).to.have.length(2)
+		expect(component.find('.balance-info').children().first().text()).to.contain('Confirmed Balance: 10 SC')
+		expect(component.find('.balance-info').children().last().text()).to.contain('Unconfirmed Delta: 1 SC')
+	})
+	it('renders siafund balance when it is non-zero', () => {
+		const component = shallow(<BalanceInfo synced confirmedbalance="10" unconfirmedbalance="1" siafundbalance="1" />)
+		expect(component.find('.balance-info').children()).to.have.length(3)
+		expect(component.find('.balance-info').children().last().text()).to.contain('Siafund Balance: 1 SF')
+	})
+	it('renders a warning when not synced', () => {
+		const component = shallow(<BalanceInfo synced={false} confirmedbalance="10" unconfirmedbalance="1" siafundbalance="0" />)
+		expect(component.find('.balance-info').children()).to.have.length(3)
+		expect(component.find('.balance-info').children().last().text()).to.contain('Your wallet is not synced, balances are not final.')
+	})
+})

--- a/test/wallet/wallet.component.js
+++ b/test/wallet/wallet.component.js
@@ -18,22 +18,6 @@ describe('wallet component', () => {
 	afterEach(() => {
 		testActions.startSendPrompt.reset()
 	})
-	it('renders balance info', () => {
-		const walletComponent = shallow(<Wallet synced confirmedbalance="10" unconfirmedbalance="1" siafundbalance="0" />)
-		expect(walletComponent.find('.balance-info').children()).to.have.length(2)
-		expect(walletComponent.find('.balance-info').children().first().text()).to.contain('Confirmed Balance: 10 SC')
-		expect(walletComponent.find('.balance-info').children().last().text()).to.contain('Unconfirmed Delta: 1 SC')
-	})
-	it('renders siafund balance when it is non-zero', () => {
-		const walletComponent = shallow(<Wallet synced confirmedbalance="10" unconfirmedbalance="1" siafundbalance="1" />)
-		expect(walletComponent.find('.balance-info').children()).to.have.length(3)
-		expect(walletComponent.find('.balance-info').children().last().text()).to.contain('Siafund Balance: 1 SF')
-	})
-	it('renders a warning when not synced', () => {
-		const walletComponent = shallow(<Wallet synced={false} confirmedbalance="10" unconfirmedbalance="1" siafundbalance="0" />)
-		expect(walletComponent.find('.balance-info').children()).to.have.length(3)
-		expect(walletComponent.find('.balance-info').children().last().text()).to.contain('Your wallet is not synced, balances are not final.')
-	})
 	it('renders siacoin send button when siafund balance is zero', () => {
 		const walletComponent = shallow(<Wallet synced confirmedbalance="10" unconfirmedbalance="1" siafundbalance="0" />)
 		expect(walletComponent.find('SendButton')).to.have.length(1)


### PR DESCRIPTION
Closes #704. The user's siacoin claims, if they have any, will now be displayed in the wallet's balance.