### PR TITLE
Added info to file plugin "no files uploaded" to always backup upload…

### DIFF
--- a/plugins/Files/js/components/filelist.js
+++ b/plugins/Files/js/components/filelist.js
@@ -122,7 +122,7 @@ const FileList = ({files, selected, searchResults, path, showSearchField, dragFi
 			{showSearchField ? <SearchField /> : null}
 			<ul>
 				<DirectoryInfoBar path={path} nfiles={files.size} onBackClick={onBackClick} setDragFolderTarget={actions.setDragFolderTarget} />
-				{ fileElements.size > 0 ? fileElements : <h2> No files uploaded </h2> }
+				{ fileElements.size > 0 ? fileElements : <h2> No files uploaded. Always backup uploaded files. SIA is not yet production ready. </h2> }
 			</ul>
 			{selected.size > 0 ? <FileControls /> : null}
 		</div>


### PR DESCRIPTION
From time to time there are reports by users of the SIA UI who claim they lost files they uploaded. I've integrated a simple message shown in the empty file panel to always backup uploaded files at this time. This solves #692 