### PR TITLE
UI Electron inspect debugging on port 9222 when debug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "start": "webpack && electron .",
-    "debug": "webpack -d && electron .",
+    "debug": "webpack -d && electron --remote-debugging-port=9222 .",
     "build-production": "webpack --config ./webpack.production.config.js",
     "build": "webpack",
     "watch": "webpack --watch",


### PR DESCRIPTION
I've noticed that there is no inspect element on the UI and that doing it on the main UI itself doesn't let you inspect the webviews inside it.