### PR TITLE
add 'show sia data' to about plugin

### DIFF
--- a/plugins/About/index.html
+++ b/plugins/About/index.html
@@ -33,6 +33,9 @@
 			<div class='about'>
 				<button id='updatecheck'>Check for Update</button>
 			</div>
+			<div class='about'>
+				<button id='datadiropen'>Show Sia Data</button>
+			</div>
 			<div id='nonew' class='about' style='display:none'>
 				You are on the latest version.
 			</div>

--- a/plugins/About/js/index.js
+++ b/plugins/About/js/index.js
@@ -1,5 +1,6 @@
 'use strict'
 import { platform } from 'os'
+import { shell } from 'electron'
 
 // Set UI version via package.json.
 document.getElementById('uiversion').innerHTML = VERSION
@@ -39,3 +40,6 @@ function updateCheck() {
 }
 
 document.getElementById('updatecheck').onclick = updateCheck
+document.getElementById('datadiropen').onclick = () => {
+	shell.showItemInFolder(SiaAPI.config.siad.datadir)
+}

--- a/plugins/Files/css/files.css
+++ b/plugins/Files/css/files.css
@@ -188,6 +188,7 @@ div[tabindex="1"]:focus {
 
 .files-toolbar {
 	width: 100%;
+	padding-left: 20px;
 	height: 50px;
 	min-width: 800px;
 	white-space: nowrap;


### PR DESCRIPTION
This PR adds a button which opens up their Sia data in their file browser, from the about plugin. Also fixes a styling issue with the files plugin.