### PR TITLE
calculate and display download speed

### DIFF
--- a/plugins/Files/js/components/transfer.js
+++ b/plugins/Files/js/components/transfer.js
@@ -2,12 +2,13 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import ProgressBar from './progressbar.js'
 
-const Transfer = ({name, progress, status, onClick}) => (
+const Transfer = ({name, progress, status, speed, onClick}) => (
 	<li className="filetransfer" onClick={onClick}>
 		<div className="transfer-info">
 			<div className="transfername">{name}</div>
 			<ProgressBar progress={progress} />
-			<span className="transfer-status">{status}</span>
+			{status === 'Downloading' && <span className="transfer-status">{status} - {speed}</span>}
+			{status === 'Completed' && <span className="transfer-status">{status}</span>}
 		</div>
 	</li>
 )

--- a/plugins/Files/js/components/transfer.js
+++ b/plugins/Files/js/components/transfer.js
@@ -2,16 +2,18 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import ProgressBar from './progressbar.js'
 
-const Transfer = ({name, progress, status, speed, onClick}) => (
-	<li className="filetransfer" onClick={onClick}>
-		<div className="transfer-info">
-			<div className="transfername">{name}</div>
-			<ProgressBar progress={progress} />
-			{status === 'Downloading' && <span className="transfer-status">{status} - {speed}</span>}
-			{status === 'Completed' && <span className="transfer-status">{status}</span>}
-		</div>
-	</li>
-)
+const Transfer = ({name, progress, status, speed, onClick}) => {
+	const statusText = (status === 'Downloading') ? status + ' - ' + speed : status
+	return (
+		<li className="filetransfer" onClick={onClick}>
+			<div className="transfer-info">
+				<div className="transfername">{name}</div>
+				<ProgressBar progress={progress} />
+				<span className="transfer-status">{statusText}</span>
+			</div>
+		</li>
+	)
+}
 
 Transfer.propTypes = {
 	name: PropTypes.string.isRequired,

--- a/plugins/Files/js/components/transferlist.js
+++ b/plugins/Files/js/components/transferlist.js
@@ -7,7 +7,7 @@ const defaultTransferClick = () => () => {}
 
 const TransferList = ({transfers, onTransferClick = defaultTransferClick}) => {
 	const transferComponents = transfers.map((transfer, key) => (
-		<Transfer key={key} status={transfer.status} name={transfer.name} progress={transfer.progress} onClick={onTransferClick(transfer)} />
+		<Transfer key={key} status={transfer.status} name={transfer.name} progress={transfer.progress} speed={transfer.speed} onClick={onTransferClick(transfer)} />
 	))
 	return (
 		<ul className="transfer-list">

--- a/plugins/Files/js/sagas/helpers.js
+++ b/plugins/Files/js/sagas/helpers.js
@@ -195,6 +195,10 @@ export const parseDownloads = (downloads) =>
 		}))
 		.sortBy((download) => -download.starttime)
 
+// Take a map of our historical transfer times, keyed by siapath, along with our most recent transfers,
+// and return a new map with the most recent data appended. Beyond a threshold, old transfer time data
+// is also discarded, so the returned map represents windows of timestamped byte counts over which we
+// can calculate average transfer speeds.
 export const buildTransferTimes = (previousTransferTimes, transfers) => {
 	// Need a finite lookback window, lest we leak memory. This is also the window over which
 	// we calculate our average speed. This number can be adjusted.
@@ -214,6 +218,7 @@ export const buildTransferTimes = (previousTransferTimes, transfers) => {
 	}, Map())
 }
 
+// Take a transfer time window and return an average speed in human-readable form
 const calculateSpeed = (transferTime) => {
 	const bytes = transferTime.bytes
 	const timestamps = transferTime.timestamps
@@ -231,6 +236,7 @@ const calculateSpeed = (transferTime) => {
 	return readableSpeed
 }
 
+// Take a list of untimed transfers and a transfer time window map and return a list of timed transfers
 export const addTransferSpeeds = (untimedTransfers, transferTimes) =>
 	untimedTransfers.map((transfer) => {
 		const transferTime = transferTimes.get(transfer.siapath)


### PR DESCRIPTION
I added a handy speed calculator for downloads, as shown in the attached screenshot. The code should be easily extensible to uploads, but I stopped with the download code because I found the "uploadprogress" field from the /renter/files API to be much less intuitive than the bytes "received" field from the /renter/downloads. Is there a reason why /renter/files has a percentage field instead of an "uploaded" analogue to "received"?

<img width="1269" alt="speed" src="https://user-images.githubusercontent.com/121910/32428424-3de7493c-c28b-11e7-9864-db81169fb19f.png">
