### PR TITLE
Check env for app.html entry

### DIFF
--- a/js/mainjs/initWindow.js
+++ b/js/mainjs/initWindow.js
@@ -45,7 +45,10 @@ export default function (config) {
   mainWindow.on('resize', onBoundsChange(mainWindow, config))
 
   // Load the index.html of the app.
-  mainWindow.loadURL(Path.join('file://', process.cwd(), 'app.html'))
+  const appEntry = process.env.NODE_ENV === 'development'
+    ? process.cwd()
+    : app.getAppPath()
+  mainWindow.loadURL(Path.join('file://', appEntry, 'app.html'))
   // Choose not to show the menubar
   if (process.platform !== 'darwin') {
     mainWindow.setMenuBarVisibility(false)


### PR DESCRIPTION
This fixes the white-screen problem on the latest RC build. I enabled a debug tool and noticed that electron was trying to load `file://app.html`. This is because it's using process.cwd() which is necessary in dev mode, but breaks in prod mode.

I added a flag to check the node env, and then use app.getAppPath() instead of process.cwd() for production builds. 